### PR TITLE
Pan zoom

### DIFF
--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1239,8 +1239,6 @@ Licensed under the MIT license.
                         // move the window to fit the new data inside, but keep the width constant
                         max = axis.datamax;
                         min = Math.max(axis.datamax - (opts.windowSize || 100), min);
-                        min -= opts.minOffset || 0;
-                        max -= opts.maxOffset || 0;
                     }
                     break;
                 case "loose":
@@ -1254,18 +1252,11 @@ Licensed under the MIT license.
 
                         min -= delta * margin;
                         max += delta * margin;
-
-                        // add the zoom offset
-                        min -= opts.minShifted || 0;
-                        max -= opts.maxShifted || 0;
                     }
                     break;
                 case "exact":
                     min = (axis.datamin != null ? axis.datamin : opts.min);
                     max = (axis.datamax != null ? axis.datamax : opts.max);
-                                            // add the zoom offset
-                        min -= opts.minShifted || 0;
-                        max -= opts.maxShifted || 0;
                     break;
             }
 

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1242,11 +1242,10 @@ Licensed under the MIT license.
                     max = +(opts.max != null ? opts.max : axis.datamax);
                     break;
                 case "loose":
-                    if(axis.datamin != null || axis.datamax != null) {
-                        min = isNaN(axis.datamin) ? opts.min : axis.datamin;
-                        max = isNaN(axis.datamin) ? opts.max : axis.datamax;
+                    if(axis.datamin != null && axis.datamax != null) {
+                        min = axis.datamin;
+                        max = axis.datamax;
 
-                        
                         delta = max - min;
                         var margin = ((opts.autoscaleMargin === 'number') ? opts.autoscaleMargin : 0.02);
 

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1243,8 +1243,8 @@ Licensed under the MIT license.
                     break;
                 case "loose":
                     if(axis.datamin != null || axis.datamax != null) {
-                        min = axis.datamin || opts.min;
-                        max = axis.datamax || opts.max;
+                        min = isNaN(axis.datamin) ? opts.min : axis.datamin;
+                        max = isNaN(axis.datamin) ? opts.max : axis.datamax;
 
                         
                         delta = max - min;

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1239,6 +1239,8 @@ Licensed under the MIT license.
                         // move the window to fit the new data inside, but keep the width constant
                         max = axis.datamax;
                         min = Math.max(axis.datamax - (opts.windowSize || 100), min);
+                        min -= opts.minOffset || 0;
+                        max -= opts.maxOffset || 0;
                     }
                     break;
                 case "loose":
@@ -1246,16 +1248,24 @@ Licensed under the MIT license.
                         min = axis.datamin || opts.min;
                         max = axis.datamax || opts.max;
 
+                        
                         delta = max - min;
                         var margin = ((opts.autoscaleMargin === 'number') ? opts.autoscaleMargin : 0.02);
 
                         min -= delta * margin;
                         max += delta * margin;
+
+                        // add the zoom offset
+                        min -= opts.minShifted || 0;
+                        max -= opts.maxShifted || 0;
                     }
                     break;
                 case "exact":
                     min = (axis.datamin != null ? axis.datamin : opts.min);
                     max = (axis.datamax != null ? axis.datamax : opts.max);
+                                            // add the zoom offset
+                        min -= opts.minShifted || 0;
+                        max -= opts.maxShifted || 0;
                     break;
             }
 

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -50,7 +50,7 @@ Licensed under the MIT license.
                     min: null, // min. value to show, null means set automatically
                     max: null, // max. value to show, null means set automatically
                     autoscaleMargin: null, // margin in % to add if autoscale option is on "loose" mode
-                    autoscale: "exact", // Available modes: "none", "loose", "exact", "window"
+                    autoscale: "exact", // Available modes: "none", "loose", "exact"
                     growOnly: null, // grow only, useful for smoother auto-scale, the scales will grow to accomodate data but won't shrink back.
                     ticks: null, // either [1, 3] or [[1, "a"], 3] or (fn: axis info -> ticks) or app. number of ticks for auto-ticks
                     tickFormatter: null, // fn: number -> string
@@ -69,7 +69,7 @@ Licensed under the MIT license.
                 },
                 yaxis: {
                     autoscaleMargin: 0.02, // margin in % to add if autoscale option is on "loose" mode
-                    autoscale: "loose", // Available modes: "none", "loose", "exact", "window"
+                    autoscale: "loose", // Available modes: "none", "loose", "exact"
                     growOnly: null, // grow only, useful for smoother auto-scale, the scales will grow to accomodate data but won't shrink back.
                     position: "left", // or "right"
                     showTickLabels: "major" // "none", "endpoints", "major", "all"
@@ -1224,7 +1224,6 @@ Licensed under the MIT license.
 
         function setRange(axis) {
             var opts = axis.options,
-                windowWidth = opts.windowSize,
                 min = axis.min || opts.min,
                 max = axis.max || opts.max,
                 delta;
@@ -1233,13 +1232,6 @@ Licensed under the MIT license.
                 case "none":
                     min = +(opts.min != null ? opts.min : axis.datamin);
                     max = +(opts.max != null ? opts.max : axis.datamax);
-                    break;
-                case "window":
-                    if(axis.datamax > max) {
-                        // move the window to fit the new data inside, but keep the width constant
-                        max = axis.datamax;
-                        min = Math.max(axis.datamax - (opts.windowSize || 100), min);
-                    }
                     break;
                 case "loose":
                     if(axis.datamin != null || axis.datamax != null) {

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -50,7 +50,7 @@ Licensed under the MIT license.
                     min: null, // min. value to show, null means set automatically
                     max: null, // max. value to show, null means set automatically
                     autoscaleMargin: null, // margin in % to add if autoscale option is on "loose" mode
-                    autoscale: "exact", // Available modes: "none", "loose", "exact",
+                    autoscale: "exact", // Available modes: "none", "loose", "exact", "window"
                     growOnly: null, // grow only, useful for smoother auto-scale, the scales will grow to accomodate data but won't shrink back.
                     ticks: null, // either [1, 3] or [[1, "a"], 3] or (fn: axis info -> ticks) or app. number of ticks for auto-ticks
                     tickFormatter: null, // fn: number -> string
@@ -69,7 +69,7 @@ Licensed under the MIT license.
                 },
                 yaxis: {
                     autoscaleMargin: 0.02, // margin in % to add if autoscale option is on "loose" mode
-                    autoscale: "loose", // Available modes: "none", "loose", "exact"
+                    autoscale: "loose", // Available modes: "none", "loose", "exact", "window"
                     growOnly: null, // grow only, useful for smoother auto-scale, the scales will grow to accomodate data but won't shrink back.
                     position: "left", // or "right"
                     showTickLabels: "major" // "none", "endpoints", "major", "all"
@@ -1224,8 +1224,9 @@ Licensed under the MIT license.
 
         function setRange(axis) {
             var opts = axis.options,
-                min,
-                max,
+                windowWidth = opts.windowSize,
+                min = axis.min || opts.min,
+                max = axis.max || opts.max,
                 delta;
 
             switch (opts.autoscale) {
@@ -1233,17 +1234,23 @@ Licensed under the MIT license.
                     min = +(opts.min != null ? opts.min : axis.datamin);
                     max = +(opts.max != null ? opts.max : axis.datamax);
                     break;
-                case "loose":
-                    if(axis.datamin != null && axis.datamax != null) {
-                        min = axis.datamin;
+                case "window":
+                    if(axis.datamax > max) {
+                        // move the window to fit the new data inside, but keep the width constant
                         max = axis.datamax;
+                        min = Math.max(axis.datamax - (opts.windowSize || 100), min);
+                    }
+                    break;
+                case "loose":
+                    if(axis.datamin != null || axis.datamax != null) {
+                        min = axis.datamin || opts.min;
+                        max = axis.datamax || opts.max;
+
                         delta = max - min;
                         var margin = ((opts.autoscaleMargin === 'number') ? opts.autoscaleMargin : 0.02);
+
                         min -= delta * margin;
                         max += delta * margin;
-                    } else {
-                        min = opts.min;
-                        max = opts.max;
                     }
                     break;
                 case "exact":
@@ -1252,8 +1259,8 @@ Licensed under the MIT license.
                     break;
             }
 
-            min = (min == undefined ? null : min);
-            max = (max == undefined ? null : max);
+            min = (isNaN(min) ? null : min);
+            max = (isNaN(max) ? null : max);
             delta = max - min;
             if (delta == 0.0) {
                 // degenerate case
@@ -1270,7 +1277,7 @@ Licensed under the MIT license.
             }
 
             // grow loose or grow exact
-            if(opts.autoscale !== "none" && opts.growOnly === true) {
+            if(opts.autoscale !== "none" && opts.autoscale !== "window" && opts.growOnly === true) {
                 min = (min < axis.datamin) ? min : axis.datamin;
                 max = (max > axis.datamax) ? max : axis.datamax;
             }

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1278,7 +1278,7 @@ Licensed under the MIT license.
             }
 
             // grow loose or grow exact
-            if(opts.autoscale !== "none" && opts.autoscale !== "window" && opts.growOnly === true) {
+            if(opts.autoscale !== "none" && opts.growOnly === true) {
                 min = (min < axis.datamin) ? min : axis.datamin;
                 max = (max > axis.datamax) ? max : axis.datamax;
             }

--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -379,8 +379,9 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
                     range = opts.transform(max) - opts.transform(min);
                 }
 
-                opts.minShifted = (opts.minShifted || 0) + (axis.min - min);
-                opts.maxShifted = (opts.maxShifted || 0) + (axis.max - max);
+                opts.min = min;
+                opts.max = max;
+                opts.autoscale = "none";
             });
 
             plot.setupGrid();
@@ -412,8 +413,9 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
                 if (d !== 0) {
                     min = axis.c2p(axis.p2c(axis.min) + d);
                     max = axis.c2p(axis.p2c(axis.max) + d);
-                    opts.minShifted = (opts.minShifted || 0) + (axis.min - min);
-                    opts.maxShifted = (opts.maxShifted || 0) + (axis.max - max);
+                    opts.min = min;
+                    opts.max = max;
+                    opts.autoscale = "none";
                 }
             });
 
@@ -484,8 +486,12 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
                 if (d !== 0) {
                     min = axis.c2p(axis.p2c(axis.savedMin) + d);
                     max = axis.c2p(axis.p2c(axis.savedMax) + d);
-                    opts.minShifted = (opts.minShifted || 0) + (axis.min - min);
-                    opts.maxShifted = (opts.maxShifted || 0) + (axis.max - max);
+                    opts.min = min;
+                    opts.max = max;
+                    opts.autoscale = "none";
+                }else {
+                    opts.min = opts.savedMin;
+                    opts.max = opts.savedMax;
                 }
             });
 

--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -489,9 +489,6 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
                     opts.min = min;
                     opts.max = max;
                     opts.autoscale = "none";
-                }else {
-                    opts.min = opts.savedMin;
-                    opts.max = opts.savedMax;
                 }
             });
 

--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -379,8 +379,8 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
                     range = opts.transform(max) - opts.transform(min);
                 }
 
-                opts.min = min;
-                opts.max = max;
+                opts.minShifted = (opts.minShifted || 0) + (axis.min - min);
+                opts.maxShifted = (opts.maxShifted || 0) + (axis.max - max);
             });
 
             plot.setupGrid();
@@ -412,8 +412,8 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
                 if (d !== 0) {
                     min = axis.c2p(axis.p2c(axis.min) + d);
                     max = axis.c2p(axis.p2c(axis.max) + d);
-                    opts.min = min;
-                    opts.max = max;
+                    opts.minShifted = (opts.minShifted || 0) + (axis.min - min);
+                    opts.maxShifted = (opts.maxShifted || 0) + (axis.max - max);
                 }
             });
 
@@ -484,11 +484,8 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
                 if (d !== 0) {
                     min = axis.c2p(axis.p2c(axis.savedMin) + d);
                     max = axis.c2p(axis.p2c(axis.savedMax) + d);
-                    opts.min = min;
-                    opts.max = max;
-                } else {
-                    opts.min = opts.savedMin;
-                    opts.max = opts.savedMax;
+                    opts.minShifted = (opts.minShifted || 0) + (axis.min - min);
+                    opts.maxShifted = (opts.maxShifted || 0) + (axis.max - max);
                 }
             });
 


### PR DESCRIPTION
In flot.navigate when interaction with the plot is in progress, the auto-scale will be disabled.
The auto-scale will be recovered at double-click.

PS: changes only in jquerry.flot.navigate.js