### PR TITLE
Updating coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# engineering-flot [![Build Status](https://travis-ci.org/ni-kismet/engineering-flot.svg?branch=master)](https://travis-ci.org/ni-kismet/engineering-flot) [![Coverage Status](https://coveralls.io/repos/github/cipix2000/engineering-flot/badge.svg?branch=master)](https://coveralls.io/github/cipix2000/engineering-flot?branch=master)
+# engineering-flot [![Build Status](https://travis-ci.org/ni-kismet/engineering-flot.svg?branch=master)](https://travis-ci.org/ni-kismet/engineering-flot) [![Coverage Status](https://coveralls.io/repos/github/ni-kismet/engineering-flot/badge.svg?branch=master)](https://coveralls.io/github/ni-kismet/engineering-flot?branch=master)
 
 ## About ##
 


### PR DESCRIPTION
The badge is now pointing to this: https://coveralls.io/github/ni-kismet/engineering-flot