### PR TITLE
Rehandled check for negative precision in logAxis formatter

### DIFF
--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -2137,7 +2137,7 @@ Licensed under the MIT license.
                 ++dec;
             }
 
-            return dec >= 0 ? dec : 0;
+            return dec;
         };
 
         function computeTickSize(min, max, direction, options, tickDecimals) {

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1414,7 +1414,7 @@ Licensed under the MIT license.
                 ++dec;
             }
 
-            return dec >= 0 ? dec : 0;
+            return dec;
         };
 
         function computeTickSize(min, max, direction, options, tickDecimals) {

--- a/jquery.flot.logaxis.js
+++ b/jquery.flot.logaxis.js
@@ -165,7 +165,7 @@ Set axis.mode to "log" to enable.
             roundWith = Math.pow(10, tenExponent),
             x = Math.round(value / roundWith);
 
-        if (precision) {
+        if (precision && precision > 0) {
             if ((tenExponent >= -4) && (tenExponent <= 4)) {
                 return defaultTickFormatter(value, axis, precision);
             } else {

--- a/jquery.flot.logaxis.js
+++ b/jquery.flot.logaxis.js
@@ -165,7 +165,10 @@ Set axis.mode to "log" to enable.
             roundWith = Math.pow(10, tenExponent),
             x = Math.round(value / roundWith);
 
-        if (precision && precision > 0) {
+        if (precision) {
+            if (precision < 0) {
+                precision = 0;
+            }
             if ((tenExponent >= -4) && (tenExponent <= 4)) {
                 return defaultTickFormatter(value, axis, precision);
             } else {

--- a/tests/jquery.flot-precision.Test.js
+++ b/tests/jquery.flot-precision.Test.js
@@ -54,7 +54,7 @@ describe("unit tests for the precision of axis", function() {
             [1, 1.1, 5, 2],
             [0.99963, 0.99964, null, 6],
             [1, 1.00000000000001, 10, 16],
-            [-200000, 200000, undefined, 0]
+            [-200000, 200000, undefined, -4]
             ];
 
         testVector.forEach(function (t) {

--- a/tests/jquery.flot.logaxis.Test.js
+++ b/tests/jquery.flot.logaxis.Test.js
@@ -65,16 +65,9 @@ describe("unit tests for the log scale functions", function() {
         var logFormatter = $.plot.logTickFormatter,
             axis = [],
             precision = -2,
-            testVector = [
-            [801, '800'],
-            ];
+            testVector = [801, '801'];
 
-        testVector.forEach(function (t) {
-            var inputValue = t[0],
-                expectedValue = t[1];
-
-            expect(logFormatter(inputValue, axis, precision)).toBe(expectedValue);
-        });
+        expect(logFormatter(testVector[0], axis, precision)).toBe(testVector[1]);
     });
 
 });


### PR DESCRIPTION
The quick fix that was made before could mess with the precision formula for axis that uses SI notation