### PR TITLE
Remove axis labels on shutdown

### DIFF
--- a/API.md
+++ b/API.md
@@ -281,7 +281,7 @@ xaxis, yaxis: {
     tickLength: null or number
 
     alignTicksWithAxis: null or number
-    
+
     offset: null or object({ below: number, above: number })
 }
 ```
@@ -1216,22 +1216,28 @@ can call:
     Cleans up any event handlers Flot has currently registered. This
     is used internally.
 
+ - isShutdown()
+
+    Returns true if the shutdown() function was called before or a new plot
+    object was created on the same placeholder with the curent one. If this
+    function is returning true then this plot should not be used anymore.
+
  - findNearbyItem(mouseX, mouseY, seriesFilter, radius, computeDistance)
-    
+
     Returns the closest item to the position determined by mouseX and
     mouseY. The series on which the search is realised can be specified
     using seriesFilter function.
     The search area will be a circle if the function is called without the
     last parameter, otherwise the distance will be computed based on given
     function.
- 
+
  - computeValuePrecision(min, max, direction, ticks, tickDecimals)
 
-    Used for determining the the precision for a certain axis. 
-    If the tickDecimals is specified, the maximum precision 
-    would be at most tickDecimals. Otherwise, it would be computed 
+    Used for determining the the precision for a certain axis.
+    If the tickDecimals is specified, the maximum precision
+    would be at most tickDecimals. Otherwise, it would be computed
     based on the axis minimum and maximum and the number of ticks.
- 
+
 There are also some members that let you peek inside the internal
 workings of Flot which is useful in some cases. Note that if you change
 something in the objects returned, you're changing the objects used by

--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -907,7 +907,8 @@ Licensed under the MIT license.
                 drawOverlay: [],
                 shutdown: []
             },
-            plot = this;
+            plot = this,
+            isShutdown = false;
 
         // interactive features
 
@@ -972,6 +973,9 @@ Licensed under the MIT license.
             };
         };
         plot.shutdown = shutdown;
+        plot.isShutdown = function() {
+            return isShutdown;
+        };
         plot.destroy = function() {
             shutdown();
             placeholder.removeData("plot").empty();
@@ -1674,6 +1678,8 @@ Licensed under the MIT license.
             eventHolder.unbind("click", onClick);
 
             executeHooks(hooks.shutdown, [eventHolder]);
+
+            isShutdown = true;
         }
 
         function setTransformationHelpers(axis) {

--- a/jquery.flot.axislabels.js
+++ b/jquery.flot.axislabels.js
@@ -207,6 +207,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     axisLabels[axisName].draw(axis.box);
                 });
             });
+
+            plot.hooks.shutdown.push(function(plot, eventHolder) {
+                for (var axisName in axisLabels) {
+                    axisLabels[axisName].cleanup();
+                }
+            });
         });
     };
 

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -183,7 +183,8 @@ Licensed under the MIT license.
                 drawOverlay: [],
                 shutdown: []
             },
-            plot = this;
+            plot = this,
+            isShutdown = false;
 
         // interactive features
 
@@ -248,6 +249,9 @@ Licensed under the MIT license.
             };
         };
         plot.shutdown = shutdown;
+        plot.isShutdown = function() {
+            return isShutdown;
+        };
         plot.destroy = function() {
             shutdown();
             placeholder.removeData("plot").empty();
@@ -950,6 +954,8 @@ Licensed under the MIT license.
             eventHolder.unbind("click", onClick);
 
             executeHooks(hooks.shutdown, [eventHolder]);
+
+            isShutdown = true;
         }
 
         function setTransformationHelpers(axis) {

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -128,7 +128,7 @@ describe('flot', function() {
 
         it('should shift the axis min and max for window autoscaling if data is bigger than window', function () {
             options.xaxis = {autoscale: 'sliding-window', min: 0, max: 10};
-            options.yaxis = {autoscale: 'sliding-window', min: 0, max: 10}; 
+            options.yaxis = {autoscale: 'sliding-window', min: 0, max: 10};
             // default window size is 100
             plot = $.plot(placeholder, [[]], options);
             plot.setData([[[0, 0], [100, 100], [200, 200]]]);
@@ -313,7 +313,6 @@ describe('flot', function() {
 
     });
 
-
     describe('adjustSeriesDataRange', function() {
 
         var placeholder, plot;
@@ -401,6 +400,24 @@ describe('flot', function() {
             var yaxis = plot.getYAxes()[0];
 
             expect(yaxis.ticks).not.toEqual([]);
+        });
+    });
+
+    describe('life cycle', function() {
+        var placeholder, options = {};
+
+        beforeEach(function() {
+            placeholder = setFixtures('<div id="test-container" style="width: 600px;height: 400px">')
+                .find('#test-container');
+        });
+
+        it('should mark as shutdown the initial plot when creating a new one on the same placeholder', function () {
+            var plot = $.plot(placeholder, [[]], options);
+            expect(plot.isShutdown()).toBe(false);
+
+            var newPlot = $.plot(placeholder, [[]], options);
+            expect(plot.isShutdown()).toBe(true);
+            expect(newPlot.isShutdown()).toBe(false);
         });
     });
 });

--- a/tests/jquery.flot.axislabels.Test.js
+++ b/tests/jquery.flot.axislabels.Test.js
@@ -111,4 +111,15 @@ describe('flot axis labels plugin', function() {
         expect(labels$.length).toBe(4);
     });
 
+    it('should not duplicate the labels when the plot is recreated', function () {
+        plot = $.plot(placeholder, [[1, 2, 3]], options);
+
+        var labels$ = $('.axisLabels');
+        expect(labels$.length).toBe(4);
+
+        plot = $.plot(placeholder, [[1, 2, 3]], options);
+        labels$ = $('.axisLabels');
+        expect(labels$.length).toBe(4);
+    });
+
 });


### PR DESCRIPTION
1. The plot.hooks.shutdown handler in the axislabels plugin is optional. Flot is already doing sort of cleanup by removing all unknown nodes from the placeholder but keeping some of them for the re-usage purpose. Still I prefer to have this plugin cleaning up its own mess.

2. Exposing the isShutdown() functionality to let the chart plugin know when the plot object is obsolete and no redraw is needed. Not redrawing to an obsolete plot will fix the issue with the axis labels being drawn multiple times. This is possible because the flot was re-using the same layer each time this was called:

plot1 = $.plot(placeholder, data, options)

//change some options
plot2 = $.plot(placeholder, data, options)

//change some more options
plot3 = $.plot(placeholder, data, options)

In this case plot1, plot2 and plot 3 are pointing to the same layer for axis labels (under the same placeholder), so nasty things can happen.
