### PR TITLE
Bind dblclick event for zoom. Add support for test

### DIFF
--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -342,6 +342,7 @@ Licensed under the MIT License ~ http://threedubmedia.googlecode.com/files/MIT-L
             var o = plot.getOptions();
             if (o.zoom.interactive) {
                 eventHolder.mousewheel(onMouseWheel);
+                eventHolder.dblclick(onDblClick);
             }
 
             if (o.pan.interactive) {

--- a/tests/jquery.flot.navigate-interaction.Test.js
+++ b/tests/jquery.flot.navigate-interaction.Test.js
@@ -129,4 +129,23 @@ describe("flot navigate plugin interactions", function () {
         expect(yaxis.max).toBeCloseTo(10, 1);
     });
 
+    it('zooms mode handles event on mouse dblclick', function () {
+        plot = $.plot(placeholder, [
+            [[0, 0],
+            [10, 10]]
+        ], options);
+
+        var xaxis = plot.getXAxes()[0];
+        var yaxis = plot.getYAxes()[0];
+
+        var clientX = plot.getPlotOffset().left + xaxis.p2c(0);
+        var clientY = plot.getPlotOffset().top + yaxis.p2c(0);
+
+        eventHolder = placeholder.find('.flot-overlay')[0];
+        simulate.mouseWheel(eventHolder, clientX, clientY, 3);
+        simulate.dblclick(eventHolder, 10, 20);
+
+        spyOn(eventHolder, 'ondblclick').and.callThrough();
+    });
+
 });

--- a/tests/jquery.flot.navigate-interaction.Test.js
+++ b/tests/jquery.flot.navigate-interaction.Test.js
@@ -133,7 +133,22 @@ describe("flot navigate plugin interactions", function () {
         plot = $.plot(placeholder, [
             [[0, 0],
             [10, 10]]
-        ], options);
+        ], {
+        xaxes: [{
+            autoscale: 'exact'
+        }],
+        yaxes: [{
+            autoscale: 'exact'
+        }],
+        zoom: {
+            interactive: false,
+        },
+        pan: {
+            interactive: true
+        },
+        selection: {
+            mode: 'smart',
+        }});
 
         var xaxis = plot.getXAxes()[0];
         var yaxis = plot.getYAxes()[0];
@@ -144,10 +159,13 @@ describe("flot navigate plugin interactions", function () {
         eventHolder = placeholder.find('.flot-overlay');
         var spy = spyOn(eventHolder[0], 'ondblclick').and.callThrough();
 
-        simulate.mouseWheel(eventHolder[0], clientX, clientY, 3);
+        var spyRecenter = jasmine.createSpy('spy');
+        $(plot.getPlaceholder()).on('re-center', spyRecenter);
+
         simulate.dblclick(eventHolder[0], 10, 20);
 
         expect(spy).toHaveBeenCalled();
+        expect(spyRecenter).toHaveBeenCalled();
     });
 
 });

--- a/tests/jquery.flot.navigate-interaction.Test.js
+++ b/tests/jquery.flot.navigate-interaction.Test.js
@@ -141,11 +141,13 @@ describe("flot navigate plugin interactions", function () {
         var clientX = plot.getPlotOffset().left + xaxis.p2c(0);
         var clientY = plot.getPlotOffset().top + yaxis.p2c(0);
 
-        eventHolder = placeholder.find('.flot-overlay')[0];
-        simulate.mouseWheel(eventHolder, clientX, clientY, 3);
-        simulate.dblclick(eventHolder, 10, 20);
+        eventHolder = placeholder.find('.flot-overlay');
+        var spy = spyOn(eventHolder[0], 'ondblclick').and.callThrough();
 
-        spyOn(eventHolder, 'ondblclick').and.callThrough();
+        simulate.mouseWheel(eventHolder[0], clientX, clientY, 3);
+        simulate.dblclick(eventHolder[0], 10, 20);
+
+        expect(spy).toHaveBeenCalled();
     });
 
 });

--- a/tests/utils/simulate.js
+++ b/tests/utils/simulate.js
@@ -96,8 +96,18 @@
         dispatchEvent(el, evt);
     }
 
+    function simulateDblclick(el, x, y, button) {
+        var bBox = el.getBoundingClientRect();
+        var clickX = bBox.left + x;
+        var clickY = bBox.top + y;
+
+        var evt = mouseEvent("dblclick", clickX, clickY, clickX, clickY, button);
+        dispatchEvent(el, evt);
+    }
+
     simulate.mouseDown = simulateMouseDown;
     simulate.mouseMove = simulateMouseMove;
     simulate.mouseUp = simulateMouseUp;
     simulate.mouseWheel = simulateMouseWheel;
+    simulate.dblclick = simulateDblclick;
 })();

--- a/tests/utils/simulate.js
+++ b/tests/utils/simulate.js
@@ -103,6 +103,8 @@
 
         var evt = mouseEvent("dblclick", clickX, clickY, clickX, clickY, button);
         dispatchEvent(el, evt);
+    }
+    
     function simulateTouchStart(el, x, y) {
         sendTouchEvent(x, y, el, "touchstart");
     }

--- a/tests/utils/simulate.js
+++ b/tests/utils/simulate.js
@@ -104,7 +104,7 @@
         var evt = mouseEvent("dblclick", clickX, clickY, clickX, clickY, button);
         dispatchEvent(el, evt);
     }
-    
+
     function simulateTouchStart(el, x, y) {
         sendTouchEvent(x, y, el, "touchstart");
     }


### PR DESCRIPTION
The event listener for reCenter is defined in ni-graph-tools, so i cannot properly test it from engineering-flot.... 