### PR TITLE
Cache axis labels

### DIFF
--- a/API.md
+++ b/API.md
@@ -1292,6 +1292,11 @@ Flot to keep track of its state, so be careful.
     Returns the canvas used for drawing in case you need to hack on it
     yourself. You'll probably need to get the plot offset too.
 
+  - getSurface()
+
+    Returns a wrapper over a canvas element that offers additional support
+    for measuring and writing text. See the CanvasWrapper plugin.
+
   - getPlotOffset()
 
     Gets the offset that the grid has within the canvas as an object

--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -931,6 +931,9 @@ Licensed under the MIT license.
         plot.getCanvas = function() {
             return surface.element;
         };
+        plot.getSurface = function() {
+            return surface;
+        };
         plot.getPlotOffset = function() {
             return plotOffset;
         };

--- a/jquery.flot.axislabels.js
+++ b/jquery.flot.axislabels.js
@@ -38,26 +38,33 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         }
     };
 
-    function AxisLabel(axisName, position, padding, placeholder, axisLabel) {
+    function AxisLabel(axisName, position, padding, placeholder, axisLabel, surface) {
         this.axisName = axisName;
         this.position = position;
         this.padding = padding;
         this.placeholder = placeholder;
         this.axisLabel = axisLabel;
+        this.surface = surface;
         this.width = 0;
         this.height = 0;
         this.elem = null;
     }
 
     AxisLabel.prototype.calculateSize = function() {
-        var div = document.createElement('div'),
-            classNameId = this.axisName + 'Label';
-        div.className = classNameId + ' axisLabels';
+        /*var div = document.createElement('div'),*/
+        var axisId = this.axisName + 'Label',
+            layerId = axisId + 'Layer',
+            className = axisId + ' axisLabels';
+        /*div.className = className;
         div.style.position = 'absolute';
         div.textContent = this.axisLabel;
-        this.placeholder.appendChild(div);
+        this.placeholder.appendChild(div);*/
 
-        var box = div.getBoundingClientRect();
+        var info = this.surface.getTextInfo(layerId, this.axisLabel, className);
+        this.labelWidth = info.width;
+        this.labelHeight = info.height;
+
+        /*var box = div.getBoundingClientRect();
         this.labelWidth = box.width;
         this.labelHeight = box.height;
         this.placeholder.removeChild(div);
@@ -66,10 +73,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         this.width = this.labelWidth + this.padding;
         this.height = this.labelHeight + this.padding;
 
-        this.width = this.height = 0;
+        this.width = this.height = 0;*/
         if (this.position === 'left' || this.position === 'right') {
             this.width = this.labelHeight + this.padding;
+            this.height = this.labelWidth + this.padding;
         } else {
+            this.width = this.labelWidth + this.padding;
             this.height = this.labelHeight + this.padding;
         }
     };
@@ -135,27 +144,43 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     };
 
     AxisLabel.prototype.cleanup = function() {
-        if (this.elem) {
-            this.elem.parentNode && this.elem.parentNode.removeChild(this.elem);
-            this.elem = null;
-        }
+        //if (this.elem) {
+        //    this.elem.parentNode && this.elem.parentNode.removeChild(this.elem);
+        //    this.elem = null;
+        //}
+        var axisId = this.axisName + 'Label',
+            layerId = axisId + 'Layer',
+            className = axisId + ' axisLabels';
+        this.surface.removeText(layerId, 0, 0, this.axisLabel, className);
     };
 
     AxisLabel.prototype.draw = function(box) {
-        var classNameId = this.axisName + 'Label',
-            div = document.createElement('div'),
+        var axisId = this.axisName + 'Label',
+            layerId = axisId + 'Layer',
+            className = axisId + ' axisLabels',
+            //div = document.createElement('div'),
             offsets = this.calculateOffsets(box),
             style = $.extend(
                 { position: 'absolute' },
                 this.transforms(offsets.degrees, offsets.x, offsets.y),
                 this.transformOrigin());
-        div.className = 'axisLabels ' + classNameId;
+        //div.className = className;
+        //Object.keys(style).forEach(function(key) {
+        //    div.style[key] = style[key];
+        //});
+        //div.textContent = this.axisLabel;
+        //this.placeholder.appendChild(div);
+        //this.elem = div;
+
+        var layer = this.surface.getTextLayer(layerId);
+        layer.style.bottom = '';
+        layer.style.right = '';
+        layer.style.display = 'inline-block';
+        layer.style.whiteSpace = 'nowrap';
         Object.keys(style).forEach(function(key) {
-            div.style[key] = style[key];
+            layer.style[key] = style[key];
         });
-        div.textContent = this.axisLabel;
-        this.placeholder.appendChild(div);
-        this.elem = div;
+        this.surface.addText(layerId, 0, 0, this.axisLabel, className);
     };
 
     function init(plot) {
@@ -171,7 +196,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 var opts = axis.options;
                 var axisName = axis.direction + axis.n;
 
-                if (!opts || !axis.show) {
+                if (!opts || !opts.axisLabel || !axis.show) {
                     return;
                 }
 
@@ -185,7 +210,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 }
                 axisLabel = new AxisLabel(axisName,
                     opts.position, padding,
-                    plot.getPlaceholder()[0], opts.axisLabel);
+                    plot.getPlaceholder()[0], opts.axisLabel, plot.getSurface());
                 axisLabels[axisName] = axisLabel;
 
                 axisLabel.calculateSize();

--- a/jquery.flot.axislabels.js
+++ b/jquery.flot.axislabels.js
@@ -51,34 +51,19 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     }
 
     AxisLabel.prototype.calculateSize = function() {
-        /*var div = document.createElement('div'),*/
         var axisId = this.axisName + 'Label',
             layerId = axisId + 'Layer',
             className = axisId + ' axisLabels';
-        /*div.className = className;
-        div.style.position = 'absolute';
-        div.textContent = this.axisLabel;
-        this.placeholder.appendChild(div);*/
 
         var info = this.surface.getTextInfo(layerId, this.axisLabel, className);
         this.labelWidth = info.width;
         this.labelHeight = info.height;
 
-        /*var box = div.getBoundingClientRect();
-        this.labelWidth = box.width;
-        this.labelHeight = box.height;
-        this.placeholder.removeChild(div);
-
-        this.width = this.height = 0;
-        this.width = this.labelWidth + this.padding;
-        this.height = this.labelHeight + this.padding;
-
-        this.width = this.height = 0;*/
         if (this.position === 'left' || this.position === 'right') {
             this.width = this.labelHeight + this.padding;
-            this.height = this.labelWidth + this.padding;
+            this.height = 0;
         } else {
-            this.width = this.labelWidth + this.padding;
+            this.width = 0;
             this.height = this.labelHeight + this.padding;
         }
     };
@@ -111,8 +96,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     };
 
     AxisLabel.prototype.transformOrigin = function() {
+        var centerX = Math.round(this.labelWidth / 2) + 'px ',
+            centerY = Math.round(this.labelHeight / 2) + 'px';
         return {
-            'transform-origin': Math.round(this.labelWidth / 2) + 'px ' + Math.round(this.labelHeight / 2) + 'px'
+            'transform-origin': centerX + centerY,
+            '-moz-transform-origin': centerX + centerY,
+            '-webkit-transform-origin': centerX + centerY,
+            '-o-transform-origin': centerX + centerY,
+            '-ms-transform-origin': centerX + centerY
         };
     };
 
@@ -144,10 +135,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     };
 
     AxisLabel.prototype.cleanup = function() {
-        //if (this.elem) {
-        //    this.elem.parentNode && this.elem.parentNode.removeChild(this.elem);
-        //    this.elem = null;
-        //}
         var axisId = this.axisName + 'Label',
             layerId = axisId + 'Layer',
             className = axisId + ' axisLabels';
@@ -158,29 +145,23 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         var axisId = this.axisName + 'Label',
             layerId = axisId + 'Layer',
             className = axisId + ' axisLabels',
-            //div = document.createElement('div'),
             offsets = this.calculateOffsets(box),
-            style = $.extend(
-                { position: 'absolute' },
-                this.transforms(offsets.degrees, offsets.x, offsets.y),
-                this.transformOrigin());
-        //div.className = className;
-        //Object.keys(style).forEach(function(key) {
-        //    div.style[key] = style[key];
-        //});
-        //div.textContent = this.axisLabel;
-        //this.placeholder.appendChild(div);
-        //this.elem = div;
+            style = $.extend({
+                position: 'absolute',
+                bottom: '',
+                right: '',
+                display: 'inline-block',
+                'white-space': 'nowrap'
+            },
+            this.transforms(offsets.degrees, offsets.x, offsets.y),
+            this.transformOrigin());
 
         var layer = this.surface.getTextLayer(layerId);
-        layer.style.bottom = '';
-        layer.style.right = '';
-        layer.style.display = 'inline-block';
-        layer.style.whiteSpace = 'nowrap';
+        this.surface.addText(layerId, 0, 0, this.axisLabel, className);
+        this.surface.render();
         Object.keys(style).forEach(function(key) {
             layer.style[key] = style[key];
         });
-        this.surface.addText(layerId, 0, 0, this.axisLabel, className);
     };
 
     function init(plot) {

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -190,6 +190,9 @@ Licensed under the MIT license.
         plot.getCanvas = function() {
             return surface.element;
         };
+        plot.getSurface = function() {
+            return surface;
+        };
         plot.getPlotOffset = function() {
             return plotOffset;
         };

--- a/tests/jquery.flot.axislabels.Test.js
+++ b/tests/jquery.flot.axislabels.Test.js
@@ -71,7 +71,7 @@ describe('flot axis labels plugin', function() {
 
         var box1 = $('.x1Label')[0].getBoundingClientRect(),
             box2 = $('.x2Label')[0].getBoundingClientRect();
-        expect(box1.left + box1.width / 2).toBeCloseTo(box2.left + box2.width / 2, 0);
+        expect((box1.left + box1.width / 2) - (box2.left + box2.width / 2)).toBeLessThan(1);
     });
 
     it('centers the labels of y axes vertically', function () {


### PR DESCRIPTION
In order to improve the speed of the drawing of the axis labels, the AxisLabels plug is now refactored to take advantage of the caching mechanism of the CanvasWrapper plugin.

Performance before:
![image](https://user-images.githubusercontent.com/6563639/29022693-fe74bc94-7b72-11e7-814e-a5c3d2967445.png)

Performance after:
![image](https://user-images.githubusercontent.com/6563639/29023177-4265a952-7b75-11e7-8f55-ca2ce83726d8.png)

Each axis label has it's own div translated and rotated. I think that eventually the CanvasWrapper plugin will be able to rotate the text by itself.

For a graph like this...
![image](https://user-images.githubusercontent.com/6563639/29022545-74172fa0-7b72-11e7-9cc3-895289a0b54a.png)

This is the corresponding div soup:
![image](https://user-images.githubusercontent.com/6563639/29022508-47aba130-7b72-11e7-9a15-6149de2d6670.png)
