### PR TITLE
Adjust y axis box.left so that the axis will be next to the plot

### DIFF
--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -1978,7 +1978,7 @@ Licensed under the MIT license.
         function readjustAxisBox(axis, margins) {
             if (axis.direction === "x") {
                 if (axis.position === "bottom" && margins.bottom > plotOffset.bottom) {
-                    axis.box.top -= Math.ceil(margins.right - plotOffset.bottom);
+                    axis.box.top -= Math.ceil(margins.bottom - plotOffset.bottom);
                 }
                 if (axis.position === "top" && margins.top > plotOffset.top) {
                     axis.box.top += Math.ceil(margins.top - plotOffset.top);

--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -1965,20 +1965,31 @@ Licensed under the MIT license.
                 }
             });
 
-            if (margins.left > plotOffset.left) {
-                $.each(yaxes, function(_, axis) {
-                    readjustAxisBox(axis, margins);
-                });
-                plotOffset.left = Math.ceil(margins.left)
-            }
+            $.each(xaxes.concat(yaxes), function(_, axis) {
+                readjustAxisBox(axis, margins);
+            });
+
+            plotOffset.left = Math.ceil(Math.max(margins.left, plotOffset.left));
             plotOffset.right = Math.ceil(Math.max(margins.right, plotOffset.right));
             plotOffset.top = Math.ceil(Math.max(margins.top, plotOffset.top));
             plotOffset.bottom = Math.ceil(Math.max(margins.bottom, plotOffset.bottom));
         }
 
         function readjustAxisBox(axis, margins) {
-            if (axis.position === "left") {
-                axis.box.left += Math.ceil(margins.left - plotOffset.left);
+            if (axis.direction === "x") {
+                if (axis.position === "bottom" && margins.bottom > plotOffset.bottom) {
+                    axis.box.top -= Math.ceil(margins.right - plotOffset.bottom);
+                }
+                if (axis.position === "top" && margins.top > plotOffset.top) {
+                    axis.box.top += Math.ceil(margins.top - plotOffset.top);
+                }
+            } else {
+                if (axis.position === "left" && margins.left > plotOffset.left) {
+                    axis.box.left += Math.ceil(margins.left - plotOffset.left);
+                }
+                if (axis.position === "right" && margins.right > plotOffset.right) {
+                    axis.box.left -= Math.ceil(margins.right - plotOffset.right);
+                }
             }
         }
 

--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -1978,7 +1978,7 @@ Licensed under the MIT license.
 
         function readjustAxisBox(axis, margins) {
             if (axis.position === "left") {
-                axis.box.left += margins.left - plotOffset.left;
+                axis.box.left += Math.ceil(margins.left - plotOffset.left);
             }
         }
 

--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -1965,10 +1965,21 @@ Licensed under the MIT license.
                 }
             });
 
-            plotOffset.left = Math.ceil(Math.max(margins.left, plotOffset.left));
+            if (margins.left > plotOffset.left) {
+                $.each(yaxes, function(_, axis) {
+                    readjustAxisBox(axis, margins);
+                });
+                plotOffset.left = Math.ceil(margins.left)
+            }
             plotOffset.right = Math.ceil(Math.max(margins.right, plotOffset.right));
             plotOffset.top = Math.ceil(Math.max(margins.top, plotOffset.top));
             plotOffset.bottom = Math.ceil(Math.max(margins.bottom, plotOffset.bottom));
+        }
+
+        function readjustAxisBox(axis, margins) {
+            if (axis.position === "left") {
+                axis.box.left += margins.left - plotOffset.left;
+            }
         }
 
         function setupGrid() {

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1237,7 +1237,7 @@ Licensed under the MIT license.
         function readjustAxisBox(axis, margins) {
             if (axis.direction === "x") {
                 if (axis.position === "bottom" && margins.bottom > plotOffset.bottom) {
-                    axis.box.top -= Math.ceil(margins.right - plotOffset.bottom);
+                    axis.box.top -= Math.ceil(margins.bottom - plotOffset.bottom);
                 }
                 if (axis.position === "top" && margins.top > plotOffset.top) {
                     axis.box.top += Math.ceil(margins.top - plotOffset.top);

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1237,7 +1237,7 @@ Licensed under the MIT license.
 
         function readjustAxisBox(axis, margins) {
             if (axis.position === "left") {
-                axis.box.left += margins.left - plotOffset.left;
+                axis.box.left += Math.ceil(margins.left - plotOffset.left);
             }
         }
 

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1224,10 +1224,21 @@ Licensed under the MIT license.
                 }
             });
 
-            plotOffset.left = Math.ceil(Math.max(margins.left, plotOffset.left));
+            if (margins.left > plotOffset.left) {
+                $.each(yaxes, function(_, axis) {
+                    readjustAxisBox(axis, margins);
+                });
+                plotOffset.left = Math.ceil(margins.left)
+            }
             plotOffset.right = Math.ceil(Math.max(margins.right, plotOffset.right));
             plotOffset.top = Math.ceil(Math.max(margins.top, plotOffset.top));
             plotOffset.bottom = Math.ceil(Math.max(margins.bottom, plotOffset.bottom));
+        }
+
+        function readjustAxisBox(axis, margins) {
+            if (axis.position === "left") {
+                axis.box.left += margins.left - plotOffset.left;
+            }
         }
 
         function setupGrid() {

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1224,20 +1224,31 @@ Licensed under the MIT license.
                 }
             });
 
-            if (margins.left > plotOffset.left) {
-                $.each(yaxes, function(_, axis) {
-                    readjustAxisBox(axis, margins);
-                });
-                plotOffset.left = Math.ceil(margins.left)
-            }
+            $.each(xaxes.concat(yaxes), function(_, axis) {
+                readjustAxisBox(axis, margins);
+            });
+
+            plotOffset.left = Math.ceil(Math.max(margins.left, plotOffset.left));
             plotOffset.right = Math.ceil(Math.max(margins.right, plotOffset.right));
             plotOffset.top = Math.ceil(Math.max(margins.top, plotOffset.top));
             plotOffset.bottom = Math.ceil(Math.max(margins.bottom, plotOffset.bottom));
         }
 
         function readjustAxisBox(axis, margins) {
-            if (axis.position === "left") {
-                axis.box.left += Math.ceil(margins.left - plotOffset.left);
+            if (axis.direction === "x") {
+                if (axis.position === "bottom" && margins.bottom > plotOffset.bottom) {
+                    axis.box.top -= Math.ceil(margins.right - plotOffset.bottom);
+                }
+                if (axis.position === "top" && margins.top > plotOffset.top) {
+                    axis.box.top += Math.ceil(margins.top - plotOffset.top);
+                }
+            } else {
+                if (axis.position === "left" && margins.left > plotOffset.left) {
+                    axis.box.left += Math.ceil(margins.left - plotOffset.left);
+                }
+                if (axis.position === "right" && margins.right > plotOffset.right) {
+                    axis.box.left -= Math.ceil(margins.right - plotOffset.right);
+                }
             }
         }
 

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -793,98 +793,63 @@ describe('flot', function() {
                 .find('#test-container');
         });
 
-        it('should draw left y axis next to plot', function() {
-            var testVector = [
-                [200000000000, 4000000000000],
-                [200000000000000, 400000000000000],
-                [20000000000000000, 40000000000000000],
-                [200000000000000000, 400000000000000000],
-                [2000000000000000000, 4000000000000000000],
-                [200000000000000000000, 400000000000000000000],
-                [20000000000000000000000, 40000000000000000000000]];
+        ['left', 'right'].forEach(function(axisPosition) {
+            it('should draw ' + axisPosition + ' y axis next to plot', function() {
+                var testVector = [
+                    [200000000000, 4000000000000],
+                    [200000000000000, 400000000000000],
+                    [20000000000000000, 40000000000000000],
+                    [200000000000000000, 400000000000000000],
+                    [2000000000000000000, 4000000000000000000],
+                    [200000000000000000000, 400000000000000000000],
+                    [20000000000000000000000, 40000000000000000000000]];
 
-            testVector.forEach(function (testValue) {
-                var plot = $.plot(placeholder, [[1, 2, 3]], {
-                    xaxis: {
-                        autoscale: 'none',
-                        min: testValue[0],
-                        max: testValue[1],
-                        showTickLabels: 'all'
-                    },
-                    yaxis: {
-                        position: 'left'
-                    }});
+                testVector.forEach(function (testValue) {
+                    var plot = $.plot(placeholder, [[1, 2, 3]], {
+                        xaxis: {
+                            autoscale: 'none',
+                            min: testValue[0],
+                            max: testValue[1],
+                            showTickLabels: 'all'
+                        },
+                        yaxis: {
+                            position: axisPosition
+                        }});
 
-                var yaxis = plot.getYAxes()[0];
+                    var yaxis = plot.getYAxes()[0];
 
-                expect(yaxis.box.left + yaxis.box.width).toEqual(plot.getPlotOffset().left);
+                    if (axisPosition === 'left') {
+                        expect(yaxis.box.left + yaxis.box.width).toEqual(plot.getPlotOffset().left);
+                    } else {
+                        expect(yaxis.box.left).toEqual(plot.getPlotOffset().left + plot.width());
+                    }
+                });
             });
         });
 
-        it('should draw right y axis next to plot', function() {
-            var testVector = [
-                [200000000000, 4000000000000],
-                [200000000000000, 400000000000000],
-                [20000000000000000, 40000000000000000],
-                [200000000000000000, 400000000000000000],
-                [2000000000000000000, 4000000000000000000],
-                [200000000000000000000, 400000000000000000000],
-                [20000000000000000000000, 40000000000000000000000]];
+        ['top', 'bottom'].forEach(function(axisPosition) {
+            it('should draw ' + axisPosition + ' x axis next to plot', function() {
+                var testVector = [20, 28, 36, 44, 52, 60, 68, 76, 84];
 
-            testVector.forEach(function (testValue) {
-                var plot = $.plot(placeholder, [[1, 2, 3]], {
-                    xaxis: {
-                        autoscale: 'none',
-                        min: testValue[0],
-                        max: testValue[1],
-                        showTickLabels: 'all'
-                    },
-                    yaxis: {
-                        position: 'right'
-                    }});
+                testVector.forEach(function (fontSize) {
+                    var plot = $.plot(placeholder, [[1, 2, 3]], {
+                        xaxis: {
+                            position: axisPosition
+                        },
+                        yaxis: {
+                            font: {
+                                size: fontSize
+                            }
+                        }});
 
-                var yaxis = plot.getYAxes()[0];
+                    var xaxis = plot.getXAxes()[0];
 
-                expect(yaxis.box.left).toEqual(plot.getPlotOffset().left + plot.width());
-            });
-        });
-
-        it('should draw top x axis next to plot', function() {
-            var testVector = [20, 28, 36, 44, 52, 60, 68, 76, 84];
-
-            testVector.forEach(function (fontSize) {
-                var plot = $.plot(placeholder, [[1, 2, 3]], {
-                    xaxis: {
-                        position: 'top'
-                    },
-                    yaxis: {
-                        font: { size: fontSize
-                        }
-                    }});
-
-                var xaxis = plot.getXAxes()[0];
-
-                expect(xaxis.box.top + xaxis.box.height).toEqual(plot.getPlotOffset().top);
-            });
-        });
-
-        it('should draw bottom x axis next to plot', function() {
-            var testVector = [20, 28, 36, 44, 52, 60, 68, 76, 84];
-
-            testVector.forEach(function (fontSize) {
-                var plot = $.plot(placeholder, [[1, 2, 3]], {
-                    xaxis: {
-                        position: 'bottom'
-                    },
-                    yaxis: {
-                        font: { size: fontSize
-                        }
-                    }});
-
-                var xaxis = plot.getXAxes()[0],
-                    plotOffset = plot.getPlotOffset();
-
-                expect(xaxis.box.top).toEqual(plotOffset.top + plot.height());
+                    if (axisPosition === 'top') {
+                        expect(xaxis.box.top + xaxis.box.height).toEqual(plot.getPlotOffset().top);
+                    } else {
+                        expect(xaxis.box.top).toEqual(plot.getPlotOffset().top + plot.height());
+                    }
+                });
             });
         });
     });

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -852,5 +852,43 @@ describe('flot', function() {
                 });
             });
         });
+
+        it('should draw y axis next to plot for multiple axis on the same side', function() {
+            var testVector = [
+                [200000000000, 4000000000000],
+                [200000000000000, 400000000000000],
+                [20000000000000000, 40000000000000000],
+                [200000000000000000, 400000000000000000],
+                [2000000000000000000, 4000000000000000000],
+                [200000000000000000000, 400000000000000000000],
+                [20000000000000000000000, 40000000000000000000000]];
+
+            testVector.forEach(function (testValue) {
+                var plot = $.plot(placeholder, [[1, 2, 3]], {
+                    xaxis: {
+                        autoscale: 'none',
+                        min: testValue[0],
+                        max: testValue[1],
+                        showTickLabels: 'all',
+                        font: {
+                            size: 48
+                        }
+                    },
+                    yaxes: [{
+                        position: 'left',
+                        show: true
+                    }, {
+                        position: 'left',
+                        show: true
+                    }, {
+                        position: 'left',
+                        show: true
+                    }]});
+
+                var yaxis = plot.getYAxes()[0];
+
+                expect(yaxis.box.left + yaxis.box.width).toEqual(plot.getPlotOffset().left);
+            });
+        });
     });
 });

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -784,4 +784,38 @@ describe('flot', function() {
             expect(plot.getData()[0].datapoints.points.length).toBe(4);
         });
     });
+
+    describe('draw axis', function() {
+        var placeholder;
+
+        beforeEach(function() {
+            placeholder = setFixtures('<div id="test-container" style="width: 600px;height: 400px">')
+                .find('#test-container');
+        });
+
+        it('should draw y axis next to plot', function() {
+            var testVector = [
+                [200000000000, 4000000000000],
+                [200000000000000, 400000000000000],
+                [20000000000000000, 40000000000000000],
+                [200000000000000000, 400000000000000000],
+                [2000000000000000000, 4000000000000000000],
+                [200000000000000000000, 400000000000000000000],
+                [20000000000000000000000, 40000000000000000000000]];
+
+            testVector.forEach(function (testValue) {
+                var plot = $.plot(placeholder, [[1, 2, 3]], {
+                    xaxis: {
+                        autoscale: 'none',
+                        min: testValue[0],
+                        max: testValue[1],
+                        showTickLabels: 'all'
+                    }});
+
+                var yaxis = plot.getYAxes()[0];
+
+                expect(yaxis.box.left + yaxis.box.width).toEqual(plot.getPlotOffset().left);
+            });
+        });
+    });
 });

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -793,7 +793,7 @@ describe('flot', function() {
                 .find('#test-container');
         });
 
-        it('should draw y axis next to plot', function() {
+        it('should draw left y axis next to plot', function() {
             var testVector = [
                 [200000000000, 4000000000000],
                 [200000000000000, 400000000000000],
@@ -815,6 +815,34 @@ describe('flot', function() {
                 var yaxis = plot.getYAxes()[0];
 
                 expect(yaxis.box.left + yaxis.box.width).toEqual(plot.getPlotOffset().left);
+            });
+        });
+
+        it('should draw right y axis next to plot', function() {
+            var testVector = [
+                [200000000000, 4000000000000],
+                [200000000000000, 400000000000000],
+                [20000000000000000, 40000000000000000],
+                [200000000000000000, 400000000000000000],
+                [2000000000000000000, 4000000000000000000],
+                [200000000000000000000, 400000000000000000000],
+                [20000000000000000000000, 40000000000000000000000]];
+
+            testVector.forEach(function (testValue) {
+                var plot = $.plot(placeholder, [[1, 2, 3]], {
+                    xaxis: {
+                        autoscale: 'none',
+                        min: testValue[0],
+                        max: testValue[1],
+                        showTickLabels: 'all'
+                    },
+                    yaxis: {
+                        position: 'right'
+                    }});
+
+                var yaxis = plot.getYAxes()[0];
+
+                expect(yaxis.box.left).toEqual(plot.getPlotOffset().left + plot.width());
             });
         });
     });

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -810,6 +810,9 @@ describe('flot', function() {
                         min: testValue[0],
                         max: testValue[1],
                         showTickLabels: 'all'
+                    },
+                    yaxis: {
+                        position: 'left'
                     }});
 
                 var yaxis = plot.getYAxes()[0];
@@ -843,6 +846,45 @@ describe('flot', function() {
                 var yaxis = plot.getYAxes()[0];
 
                 expect(yaxis.box.left).toEqual(plot.getPlotOffset().left + plot.width());
+            });
+        });
+
+        it('should draw top x axis next to plot', function() {
+            var testVector = [20, 28, 36, 44, 52, 60, 68, 76, 84];
+
+            testVector.forEach(function (fontSize) {
+                var plot = $.plot(placeholder, [[1, 2, 3]], {
+                    xaxis: {
+                        position: 'top'
+                    },
+                    yaxis: {
+                        font: { size: fontSize
+                        }
+                    }});
+
+                var xaxis = plot.getXAxes()[0];
+
+                expect(xaxis.box.top + xaxis.box.height).toEqual(plot.getPlotOffset().top);
+            });
+        });
+
+        it('should draw bottom x axis next to plot', function() {
+            var testVector = [20, 28, 36, 44, 52, 60, 68, 76, 84];
+
+            testVector.forEach(function (fontSize) {
+                var plot = $.plot(placeholder, [[1, 2, 3]], {
+                    xaxis: {
+                        position: 'bottom'
+                    },
+                    yaxis: {
+                        font: { size: fontSize
+                        }
+                    }});
+
+                var xaxis = plot.getXAxes()[0],
+                    plotOffset = plot.getPlotOffset();
+
+                expect(xaxis.box.top).toEqual(plotOffset.top + plot.height());
             });
         });
     });


### PR DESCRIPTION
If x axis label width is big, the plotOffset.left will be changed based on it. This can cause the drawing of y axis not close to the plot. To fix this, the y axis box.left will be increased with the same amount as plotOffset.left.

The same problem can appear on any combination of axis with axis position after updating plotOffset.