### PR TITLE
Adjust axis and plot margins according to grid margins

### DIFF
--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -2074,7 +2074,6 @@ Licensed under the MIT license.
                     plotOffset[a] += typeof margin === "number" ? margin : margin[a] || 0;
                 }
                 $.each(xaxes.concat(yaxes), function(_, axis) {
-                    //move to axis box acording to the grid.margins
                     alignAxisWithGrid(axis, options.grid.margin, function(offset) {
                         return offset !== undefined && offset !== null;
                     });

--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -2071,7 +2071,7 @@ Licensed under the MIT license.
             if (options.grid.margin) {
                 for (a in plotOffset) {
                     var margin = options.grid.margin || 0;
-                    plotOffset[a] += typeof margin === "number" ? margin : margin[a] || 0;
+                    plotOffset[a] += typeof margin === "number" ? margin : (margin[a] || 0);
                 }
                 $.each(xaxes.concat(yaxes), function(_, axis) {
                     alignAxisWithGrid(axis, options.grid.margin, function(offset) {

--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -1970,7 +1970,7 @@ Licensed under the MIT license.
                 offset[a] = margins[a] - plotOffset[a];
             }
             $.each(xaxes.concat(yaxes), function(_, axis) {
-                allignAxisWithGrid(axis, offset, function (offset) {
+                alignAxisWithGrid(axis, offset, function (offset) {
                     return offset > 0;
                 });
             });
@@ -1981,7 +1981,7 @@ Licensed under the MIT license.
             plotOffset.bottom = Math.ceil(Math.max(margins.bottom, plotOffset.bottom));
         }
 
-        function allignAxisWithGrid(axis, offset, isValid) {
+        function alignAxisWithGrid(axis, offset, isValid) {
             if (axis.direction === "x") {
                 if (axis.position === "bottom" && isValid(offset.bottom)) {
                     axis.box.top -= Math.ceil(offset.bottom);
@@ -2075,7 +2075,7 @@ Licensed under the MIT license.
                 }
                 $.each(xaxes.concat(yaxes), function(_, axis) {
                     //move to axis box acording to the grid.margins
-                    allignAxisWithGrid(axis, options.grid.margin, function(offset) {
+                    alignAxisWithGrid(axis, options.grid.margin, function(offset) {
                         return offset !== undefined && offset !== null;
                     });
                 });

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1330,7 +1330,7 @@ Licensed under the MIT license.
             if (options.grid.margin) {
                 for (a in plotOffset) {
                     var margin = options.grid.margin || 0;
-                    plotOffset[a] += typeof margin === "number" ? margin : margin[a] || 0;
+                    plotOffset[a] += typeof margin === "number" ? margin : (margin[a] || 0);
                 }
                 $.each(xaxes.concat(yaxes), function(_, axis) {
                     alignAxisWithGrid(axis, options.grid.margin, function(offset) {

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1202,12 +1202,13 @@ Licensed under the MIT license.
                 }
             }
 
-            var margins = {
-                left: minMargin,
-                right: minMargin,
-                top: minMargin,
-                bottom: minMargin
-            };
+            var a, offset = {},
+                margins = {
+                    left: minMargin,
+                    right: minMargin,
+                    top: minMargin,
+                    bottom: minMargin
+                };
 
             // check axis labels, note we don't check the actual
             // labels but instead use the overall width/height to not
@@ -1224,8 +1225,13 @@ Licensed under the MIT license.
                 }
             });
 
+            for (a in margins) {
+                offset[a] = margins[a] - plotOffset[a];
+            }
             $.each(xaxes.concat(yaxes), function(_, axis) {
-                readjustAxisBox(axis, margins);
+                allignAxisWithGrid(axis, offset, function (offset) {
+                    return offset > 0;
+                });
             });
 
             plotOffset.left = Math.ceil(Math.max(margins.left, plotOffset.left));
@@ -1234,20 +1240,20 @@ Licensed under the MIT license.
             plotOffset.bottom = Math.ceil(Math.max(margins.bottom, plotOffset.bottom));
         }
 
-        function readjustAxisBox(axis, margins) {
+        function allignAxisWithGrid(axis, offset, isValid) {
             if (axis.direction === "x") {
-                if (axis.position === "bottom" && margins.bottom > plotOffset.bottom) {
-                    axis.box.top -= Math.ceil(margins.bottom - plotOffset.bottom);
+                if (axis.position === "bottom" && isValid(offset.bottom)) {
+                    axis.box.top -= Math.ceil(offset.bottom);
                 }
-                if (axis.position === "top" && margins.top > plotOffset.top) {
-                    axis.box.top += Math.ceil(margins.top - plotOffset.top);
+                if (axis.position === "top" && isValid(offset.top)) {
+                    axis.box.top += Math.ceil(offset.top);
                 }
             } else {
-                if (axis.position === "left" && margins.left > plotOffset.left) {
-                    axis.box.left += Math.ceil(margins.left - plotOffset.left);
+                if (axis.position === "left" && isValid(offset.left)) {
+                    axis.box.left += Math.ceil(offset.left);
                 }
-                if (axis.position === "right" && margins.right > plotOffset.right) {
-                    axis.box.left -= Math.ceil(margins.right - plotOffset.right);
+                if (axis.position === "right" && isValid(offset.right)) {
+                    axis.box.left -= Math.ceil(offset.right);
                 }
             }
         }
@@ -1259,14 +1265,12 @@ Licensed under the MIT license.
             // Initialize the plot's offset from the edge of the canvas
 
             for (a in plotOffset) {
-                var margin = options.grid.margin || 0;
-                plotOffset[a] = typeof margin === "number" ? margin : margin[a] || 0;
+                plotOffset[a] = 0;
             }
 
             executeHooks(hooks.processOffset, [plotOffset]);
 
             // If the grid is visible, add its border width to the offset
-
             for (a in plotOffset) {
                 if (typeof (options.grid.borderWidth) === "object") {
                     plotOffset[a] += showGrid ? options.grid.borderWidth[a] : 0;
@@ -1319,6 +1323,20 @@ Licensed under the MIT license.
 
                 $.each(allocatedAxes, function(_, axis) {
                     allocateAxisBoxSecondPhase(axis);
+                });
+            }
+
+            //adjust axis and plotOffset according to grid.margins
+            if (options.grid.margin) {
+                for (a in plotOffset) {
+                    var margin = options.grid.margin || 0;
+                    plotOffset[a] += typeof margin === "number" ? margin : margin[a] || 0;
+                }
+                $.each(xaxes.concat(yaxes), function(_, axis) {
+                    //move to axis box acording to the grid.margins
+                    allignAxisWithGrid(axis, options.grid.margin, function(offset) {
+                        return offset !== undefined && offset !== null;
+                    });
                 });
             }
 

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1229,7 +1229,7 @@ Licensed under the MIT license.
                 offset[a] = margins[a] - plotOffset[a];
             }
             $.each(xaxes.concat(yaxes), function(_, axis) {
-                allignAxisWithGrid(axis, offset, function (offset) {
+                alignAxisWithGrid(axis, offset, function (offset) {
                     return offset > 0;
                 });
             });
@@ -1240,7 +1240,7 @@ Licensed under the MIT license.
             plotOffset.bottom = Math.ceil(Math.max(margins.bottom, plotOffset.bottom));
         }
 
-        function allignAxisWithGrid(axis, offset, isValid) {
+        function alignAxisWithGrid(axis, offset, isValid) {
             if (axis.direction === "x") {
                 if (axis.position === "bottom" && isValid(offset.bottom)) {
                     axis.box.top -= Math.ceil(offset.bottom);
@@ -1334,7 +1334,7 @@ Licensed under the MIT license.
                 }
                 $.each(xaxes.concat(yaxes), function(_, axis) {
                     //move to axis box acording to the grid.margins
-                    allignAxisWithGrid(axis, options.grid.margin, function(offset) {
+                    alignAxisWithGrid(axis, options.grid.margin, function(offset) {
                         return offset !== undefined && offset !== null;
                     });
                 });

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -1333,7 +1333,6 @@ Licensed under the MIT license.
                     plotOffset[a] += typeof margin === "number" ? margin : margin[a] || 0;
                 }
                 $.each(xaxes.concat(yaxes), function(_, axis) {
-                    //move to axis box acording to the grid.margins
                     alignAxisWithGrid(axis, options.grid.margin, function(offset) {
                         return offset !== undefined && offset !== null;
                     });

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -907,11 +907,13 @@ describe('flot', function() {
     });
 
     describe('Grid margin', function() {
-        var placeholder;
+        var placeholder, placeholder2, fixtures;
 
         beforeEach(function() {
-            placeholder = setFixtures('<div id="test-container" style="width: 600px;height: 400px">')
-                .find('#test-container');
+            fixtures = setFixtures('<div id="test-container" style="width: 600px;height: 400px"/>' +
+                '<div id="test-container2" style="width: 600px;height: 400px"/>');
+            placeholder = fixtures.find('#test-container');
+            placeholder2 = fixtures.find('#test-container2');
         });
 
         it('should change plot dimensions', function() {
@@ -934,7 +936,7 @@ describe('flot', function() {
 
             testVector.forEach(function (testValue) {
                 var plot1 = $.plot(placeholder, [[]], {}),
-                    plot2 = $.plot(placeholder, [[]], {
+                    plot2 = $.plot(placeholder2, [[]], {
                         grid: { margin: {
                             left: testValue[0],
                             right: testValue[1],
@@ -982,7 +984,7 @@ describe('flot', function() {
                             show: true
                         }]
                     }),
-                    plot2 = $.plot(placeholder, [[]], {
+                    plot2 = $.plot(placeholder2, [[]], {
                         xaxes: [{
                             position: 'bottom',
                             show: true
@@ -1020,6 +1022,16 @@ describe('flot', function() {
                 xaxis2 = plot2.getXAxes()[1];
                 expect(xaxis1.box.top + testValue[2]).toEqual(xaxis2.box.top);
             });
+        });
+
+        it('should work for margin: number', function() {
+            var plot1 = $.plot(placeholder, [[]], {}),
+                plot2 = $.plot(placeholder2, [[]], {
+                    grid: { margin: 20 }
+                });
+
+            expect(plot2.width()).toBe(plot1.width() - 20 - 20);
+            expect(plot2.height()).toBe(plot1.height() - 20 - 20);
         });
     })
 });

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -905,4 +905,121 @@ describe('flot', function() {
             });
         });
     });
+
+    describe('Grid margin', function() {
+        var placeholder;
+
+        beforeEach(function() {
+            placeholder = setFixtures('<div id="test-container" style="width: 600px;height: 400px">')
+                .find('#test-container');
+        });
+
+        it('should change plot dimensions', function() {
+            var testVector = [
+                [-20, 0, 0, 0],
+                [20, 0, 0, 0],
+                [20, -20, 0, 0],
+                [-20, -20, 0, 0],
+                [-20, 20, 0, 0],
+                [20, 20, 0, 0],
+                [0, 0, -20, 0],
+                [0, 0, 20, 0],
+                [0, 0, -20, 20],
+                [0, 0, -20, -20],
+                [0, 0, 20, 20],
+                [0, 0, 20, -20],
+                [20, 20, 20, 20],
+                [-20, -20, -20, -20]
+            ];
+
+            testVector.forEach(function (testValue) {
+                var plot1 = $.plot(placeholder, [[]], {}),
+                    plot2 = $.plot(placeholder, [[]], {
+                        grid: { margin: {
+                            left: testValue[0],
+                            right: testValue[1],
+                            top: testValue[2],
+                            bottom: testValue[3]
+                        }}});
+
+                expect(plot2.width()).toBe(plot1.width() - testValue[0] - testValue[1]);
+                expect(plot2.height()).toBe(plot1.height() - testValue[2] - testValue[3]);
+            });
+        });
+
+        it('should move the axis according to grid margin', function() {
+            var testVector = [
+                [-20, 0, 0, 0],
+                [20, 0, 0, 0],
+                [20, -20, 0, 0],
+                [-20, -20, 0, 0],
+                [-20, 20, 0, 0],
+                [20, 20, 0, 0],
+                [0, 0, -20, 0],
+                [0, 0, 20, 0],
+                [0, 0, -20, 20],
+                [0, 0, -20, -20],
+                [0, 0, 20, 20],
+                [0, 0, 20, -20],
+                [20, 20, 20, 20],
+                [-20, -20, -20, -20]
+            ];
+
+            testVector.forEach(function (testValue) {
+                var plot1 = $.plot(placeholder, [[]], {
+                        xaxes: [{
+                            position: 'bottom',
+                            show: true
+                        }, {
+                            position: 'top',
+                            show: true
+                        }],
+                        yaxes: [{
+                            position: 'left',
+                            show: true
+                        }, {
+                            position: 'right',
+                            show: true
+                        }]
+                    }),
+                    plot2 = $.plot(placeholder, [[]], {
+                        xaxes: [{
+                            position: 'bottom',
+                            show: true
+                        }, {
+                            position: 'top',
+                            show: true
+                        }],
+                        yaxes: [{
+                            position: 'left',
+                            show: true
+                        }, {
+                            position: 'right',
+                            show: true
+                        }],
+                        grid: { margin: {
+                            left: testValue[0],
+                            right: testValue[1],
+                            top: testValue[2],
+                            bottom: testValue[3]
+                        }}});
+
+                var yaxis1 = plot1.getYAxes()[0],
+                    yaxis2 = plot2.getYAxes()[0];
+                expect(yaxis1.box.left + testValue[0]).toEqual(yaxis2.box.left);
+
+                yaxis1 = plot1.getYAxes()[1];
+                yaxis2 = plot2.getYAxes()[1];
+                expect(yaxis1.box.left - testValue[1]).toEqual(yaxis2.box.left);
+
+                var xaxis1 = plot1.getXAxes()[0],
+                    xaxis2 = plot2.getXAxes()[0];
+                expect(xaxis1.box.top - testValue[3]).toEqual(xaxis2.box.top);
+
+                xaxis1 = plot1.getXAxes()[1];
+                xaxis2 = plot2.getXAxes()[1];
+                expect(xaxis1.box.top + testValue[2]).toEqual(xaxis2.box.top);
+            });
+        });
+    })
 });


### PR DESCRIPTION
The plot area setting should specify how the plot, excluding axes (the grid of the plot) is placed according to it's area. In the case of the webcharts the entire area of the charts, including axes was specified.

Now, the plot offset will be modified accordingly and after this, the axis box position will be aligned with the plot.
