### PR TITLE
Cleanup find nearby items

### DIFF
--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -3202,7 +3202,7 @@ Licensed under the MIT license.
             series.bars.barWidth = 0.8 * minDistance;
         }
 
-        // returns the data item the mouse is over, or null if none is found
+        // returns the data item the mouse is over/ the cursor is closest to, or null if none is found
         function findNearbyItem(mouseX, mouseY, seriesFilter, radius, computeDistance) {
             var maxDistance = radius,
                 smallestDistance = maxDistance * maxDistance + 1,
@@ -3238,8 +3238,6 @@ Licensed under the MIT license.
                     y = points[j + 1];
                     if (x == null) continue;
 
-                    // For points and lines, the cursor must be within a
-                    // certain distance to the data point
                     if (x - mx > maxx || x - mx < -maxx ||
                         y - my > maxy || y - my < -maxy) {
                         continue;

--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -3233,62 +3233,29 @@ Licensed under the MIT license.
                     maxy = Number.MAX_VALUE;
                 }
 
-                if (s.lines.show || s.points.show) {
-                    for (j = 0; j < points.length; j += ps) {
-                        x = points[j];
-                        y = points[j + 1];
-                        if (x == null) continue;
+                for (j = 0; j < points.length; j += ps) {
+                    x = points[j];
+                    y = points[j + 1];
+                    if (x == null) continue;
 
-                        // For points and lines, the cursor must be within a
-                        // certain distance to the data point
-                        if (x - mx > maxx || x - mx < -maxx ||
-                            y - my > maxy || y - my < -maxy) {
-                            continue;
-                        }
-
-                        // We have to calculate distances in pixels, not in
-                        // data units, because the scales of the axes may be different
-                        var dx = Math.abs(axisx.p2c(x) - mouseX),
-                            dy = Math.abs(axisy.p2c(y) - mouseY),
-                            dist = computeDistance ? computeDistance(dx, dy) : dx * dx + dy * dy;
-
-                        // use <= to ensure last point takes precedence
-                        // (last generally means on top of)
-                        if (dist < smallestDistance) {
-                            smallestDistance = dist;
-                            item = [i, j / ps];
-                        }
-                    }
-                }
-
-                if (s.bars.show && !item) {
-                    // no other point can be nearby
-                    var barLeft, barRight;
-
-                    switch (s.bars.align) {
-                        case "left":
-                            barLeft = 0;
-                            break;
-                        case "right":
-                            barLeft = -s.bars.barWidth;
-                            break;
-                        default:
-                            barLeft = -s.bars.barWidth / 2;
+                    // For points and lines, the cursor must be within a
+                    // certain distance to the data point
+                    if (x - mx > maxx || x - mx < -maxx ||
+                        y - my > maxy || y - my < -maxy) {
+                        continue;
                     }
 
-                    barRight = barLeft + s.bars.barWidth;
+                    // We have to calculate distances in pixels, not in
+                    // data units, because the scales of the axes may be different
+                    var dx = Math.abs(axisx.p2c(x) - mouseX),
+                        dy = Math.abs(axisy.p2c(y) - mouseY),
+                        dist = computeDistance ? computeDistance(dx, dy) : dx * dx + dy * dy;
 
-                    for (j = 0; j < points.length; j += ps) {
-                        x = points[j];
-                        y = points[j + 1];
-                        var b = points[j + 2];
-                        if (x == null) continue;
-
-                        // for a bar graph, the cursor must be inside the bar
-                        if (mx >= x + barLeft && mx <= x + barRight &&
-                                my >= Math.min(b, y) && my <= Math.max(b, y)) {
-                            item = [i, j / ps];
-                        }
+                    // use <= to ensure last point takes precedence
+                    // (last generally means on top of)
+                    if (dist < smallestDistance) {
+                        smallestDistance = dist;
+                        item = [i, j / ps];
                     }
                 }
             }

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2492,62 +2492,29 @@ Licensed under the MIT license.
                     maxy = Number.MAX_VALUE;
                 }
 
-                if (s.lines.show || s.points.show) {
-                    for (j = 0; j < points.length; j += ps) {
-                        x = points[j];
-                        y = points[j + 1];
-                        if (x == null) continue;
+                for (j = 0; j < points.length; j += ps) {
+                    x = points[j];
+                    y = points[j + 1];
+                    if (x == null) continue;
 
-                        // For points and lines, the cursor must be within a
-                        // certain distance to the data point
-                        if (x - mx > maxx || x - mx < -maxx ||
-                            y - my > maxy || y - my < -maxy) {
-                            continue;
-                        }
-
-                        // We have to calculate distances in pixels, not in
-                        // data units, because the scales of the axes may be different
-                        var dx = Math.abs(axisx.p2c(x) - mouseX),
-                            dy = Math.abs(axisy.p2c(y) - mouseY),
-                            dist = computeDistance ? computeDistance(dx, dy) : dx * dx + dy * dy;
-
-                        // use <= to ensure last point takes precedence
-                        // (last generally means on top of)
-                        if (dist < smallestDistance) {
-                            smallestDistance = dist;
-                            item = [i, j / ps];
-                        }
-                    }
-                }
-
-                if (s.bars.show && !item) {
-                    // no other point can be nearby
-                    var barLeft, barRight;
-
-                    switch (s.bars.align) {
-                        case "left":
-                            barLeft = 0;
-                            break;
-                        case "right":
-                            barLeft = -s.bars.barWidth;
-                            break;
-                        default:
-                            barLeft = -s.bars.barWidth / 2;
+                    // For points and lines, the cursor must be within a
+                    // certain distance to the data point
+                    if (x - mx > maxx || x - mx < -maxx ||
+                        y - my > maxy || y - my < -maxy) {
+                        continue;
                     }
 
-                    barRight = barLeft + s.bars.barWidth;
+                    // We have to calculate distances in pixels, not in
+                    // data units, because the scales of the axes may be different
+                    var dx = Math.abs(axisx.p2c(x) - mouseX),
+                        dy = Math.abs(axisy.p2c(y) - mouseY),
+                        dist = computeDistance ? computeDistance(dx, dy) : dx * dx + dy * dy;
 
-                    for (j = 0; j < points.length; j += ps) {
-                        x = points[j];
-                        y = points[j + 1];
-                        var b = points[j + 2];
-                        if (x == null) continue;
-
-                        // for a bar graph, the cursor must be inside the bar
-                        if (mx >= x + barLeft && mx <= x + barRight &&
-                                my >= Math.min(b, y) && my <= Math.max(b, y)) {
-                            item = [i, j / ps];
-                        }
+                    // use <= to ensure last point takes precedence
+                    // (last generally means on top of)
+                    if (dist < smallestDistance) {
+                        smallestDistance = dist;
+                        item = [i, j / ps];
                     }
                 }
             }

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2461,7 +2461,7 @@ Licensed under the MIT license.
             series.bars.barWidth = 0.8 * minDistance;
         }
 
-        // returns the data item the mouse is over, or null if none is found
+        // returns the data item the mouse is over/ the cursor is closest to, or null if none is found
         function findNearbyItem(mouseX, mouseY, seriesFilter, radius, computeDistance) {
             var maxDistance = radius,
                 smallestDistance = maxDistance * maxDistance + 1,
@@ -2497,8 +2497,6 @@ Licensed under the MIT license.
                     y = points[j + 1];
                     if (x == null) continue;
 
-                    // For points and lines, the cursor must be within a
-                    // certain distance to the data point
                     if (x - mx > maxx || x - mx < -maxx ||
                         y - my > maxy || y - my < -maxy) {
                         continue;

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -419,6 +419,25 @@ describe('flot', function() {
         });
     });
 
+    describe('findNearbyItem', function() {
+        var placeholder, plot, sampledata = [[0, 1], [1, 1.1], [2, 1.2]];
+
+        beforeEach(function() {
+            placeholder = setFixtures('<div id="test-container" style="width: 600px;height: 400px">')
+                .find('#test-container');
+        });
+
+        it('should be able to find the nearest point to the given coordinates', function() {
+            plot = $.plot(placeholder, [sampledata], {});
+            var item = plot.findNearbyItem(0, 0, function() {
+                return true;
+            }, Number.MAX_VALUE);
+            expect(item.datapoint[0]).toEqual(sampledata[0][0]);
+            expect(item.datapoint[1]).toEqual(sampledata[0][1]);
+            expect(item.dataIndex).toEqual(0);
+        });
+    });
+
     describe('setupTickFormatter', function() {
         var placeholder, plot, sampledata = [[0, 1], [1, 1.1], [2, 1.2]];
 

--- a/tests/jquery.flot.Test.js
+++ b/tests/jquery.flot.Test.js
@@ -436,6 +436,30 @@ describe('flot', function() {
             expect(item.datapoint[1]).toEqual(sampledata[0][1]);
             expect(item.dataIndex).toEqual(0);
         });
+
+        it('should be able to search in a certain radius', function() {
+            plot = $.plot(placeholder, [sampledata], {});
+            var item = plot.findNearbyItem(0, 0, function() {
+                return true;
+            }, 1);
+            expect(item).toEqual(null);
+
+            item = plot.findNearbyItem(0, 0, function() {
+                return true;
+            }, 1000);
+            expect(item).not.toEqual(null);
+        });
+
+        it('should work for bars', function() {
+            plot = $.plot(placeholder, [sampledata], {
+                bars: {show: true}
+            });
+
+            item = plot.findNearbyItem(0, 0, function() {
+                return true;
+            }, 1000);
+            expect(item).not.toEqual(null);
+        });
     });
 
     describe('setupTickFormatter', function() {


### PR DESCRIPTION
FindNearbyItem function had a special mode of handling bars. 
This worked only for hover; in case of cursors most of the time it wasn't able to snap. This happened because it was snapping only if the cursor was inside the bar. There is no need to handle bars different from points. 