### PR TITLE
Shift plot colors

### DIFF
--- a/dist/jquery.flot.js
+++ b/dist/jquery.flot.js
@@ -1348,10 +1348,11 @@ Licensed under the MIT license.
             var c, colors = [],
                 colorPool = options.colors,
                 colorPoolSize = colorPool.length,
-                variation = 0;
+                variation = 0,
+                definedColors = series.length - neededColors;
 
             for (i = 0; i < neededColors; i++) {
-                c = $.color.parse(colorPool[i % colorPoolSize] || "#666");
+                c = $.color.parse(colorPool[(definedColors + i) % colorPoolSize] || "#666");
 
                 // Each time we exhaust the colors in the pool we adjust
                 // a scaling factor used to produce more variations on

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -607,10 +607,11 @@ Licensed under the MIT license.
             var c, colors = [],
                 colorPool = options.colors,
                 colorPoolSize = colorPool.length,
-                variation = 0;
+                variation = 0,
+                definedColors = series.length - neededColors;
 
             for (i = 0; i < neededColors; i++) {
-                c = $.color.parse(colorPool[i % colorPoolSize] || "#666");
+                c = $.color.parse(colorPool[(definedColors + i) % colorPoolSize] || "#666");
 
                 // Each time we exhaust the colors in the pool we adjust
                 // a scaling factor used to produce more variations on


### PR DESCRIPTION
Plot legend colors are selected based on plot index if there's no renderer.
In case we have some plot renderers defined, shift the plot colors so that the legend and plot colors are the same.