### PR TITLE
Touch axis pan fix

### DIFF
--- a/jquery.flot.touchNavigate.js
+++ b/jquery.flot.touchNavigate.js
@@ -205,7 +205,9 @@
         } else if (e.type === 'pinchend') {
             //update axis since instead on pinch, a pan event is made
             return getTouchedAxis(plot, e.detail.touches[0].pageX, e.detail.touches[0].pageY);
-        } else return navigationState.touchedAxis;
+        } else {
+            return navigationState.touchedAxis;
+        }
     }
 
     function noAxisTouched(navigationState) {

--- a/jquery.flot.touchNavigate.js
+++ b/jquery.flot.touchNavigate.js
@@ -194,8 +194,17 @@
 
     function getAxis(plot, e, gesture, navigationState) {
         if (e.detail.type === 'touchstart') {
-            var point = getPoint(e, gesture);
-            return getTouchedAxis(plot, point.x, point.y);
+            if (gesture === 'pinch') {
+                var axisTouch1 = getTouchedAxis(plot, e.detail.touches[0].pageX, e.detail.touches[0].pageY);
+                var axisTouch2 = getTouchedAxis(plot, e.detail.touches[1].pageX, e.detail.touches[1].pageY);
+                var allEqual = axisTouch1 => axisTouch1.every(v => v === axisTouch1[0]);
+                if (axisTouch1.length === axisTouch2.length && allEqual(axisTouch2)) {
+                    return axisTouch1;
+                }
+            } else return getTouchedAxis(plot, e.detail.touches[0].pageX, e.detail.touches[0].pageY);
+        } else if (e.detail.type === 'touchend' && gesture === 'pinch') {
+            //update axis since instead on pinch, a pan event is made
+            return getTouchedAxis(plot, e.detail.touches[0].pageX, e.detail.touches[0].pageY);
         } else return navigationState.touchedAxis;
     }
 

--- a/jquery.flot.touchNavigate.js
+++ b/jquery.flot.touchNavigate.js
@@ -197,8 +197,8 @@
             if (gesture === 'pinch') {
                 var axisTouch1 = getTouchedAxis(plot, e.detail.touches[0].pageX, e.detail.touches[0].pageY);
                 var axisTouch2 = getTouchedAxis(plot, e.detail.touches[1].pageX, e.detail.touches[1].pageY);
-                var allEqual = axisTouch1 => axisTouch1.every(v => v === axisTouch1[0]);
-                if (axisTouch1.length === axisTouch2.length && allEqual(axisTouch2)) {
+
+                if (axisTouch1.length === axisTouch2.length && axisTouch1.toString() === axisTouch2.toString()) {
                     return axisTouch1;
                 }
             } else return getTouchedAxis(plot, e.detail.touches[0].pageX, e.detail.touches[0].pageY);

--- a/jquery.flot.touchNavigate.js
+++ b/jquery.flot.touchNavigate.js
@@ -193,16 +193,16 @@
     }
 
     function getAxis(plot, e, gesture, navigationState) {
-        if (e.detail.type === 'touchstart') {
-            if (gesture === 'pinch') {
-                var axisTouch1 = getTouchedAxis(plot, e.detail.touches[0].pageX, e.detail.touches[0].pageY);
-                var axisTouch2 = getTouchedAxis(plot, e.detail.touches[1].pageX, e.detail.touches[1].pageY);
+        if (e.type === 'pinchstart') {
+            var axisTouch1 = getTouchedAxis(plot, e.detail.touches[0].pageX, e.detail.touches[0].pageY);
+            var axisTouch2 = getTouchedAxis(plot, e.detail.touches[1].pageX, e.detail.touches[1].pageY);
 
-                if (axisTouch1.length === axisTouch2.length && axisTouch1.toString() === axisTouch2.toString()) {
-                    return axisTouch1;
-                }
-            } else return getTouchedAxis(plot, e.detail.touches[0].pageX, e.detail.touches[0].pageY);
-        } else if (e.detail.type === 'touchend' && gesture === 'pinch') {
+            if (axisTouch1.length === axisTouch2.length && axisTouch1.toString() === axisTouch2.toString()) {
+                return axisTouch1;
+            }
+        } else if (e.type === 'panstart') {
+            return getTouchedAxis(plot, e.detail.touches[0].pageX, e.detail.touches[0].pageY);
+        } else if (e.type === 'pinchend') {
             //update axis since instead on pinch, a pan event is made
             return getTouchedAxis(plot, e.detail.touches[0].pageX, e.detail.touches[0].pageY);
         } else return navigationState.touchedAxis;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5163,15 +5163,6 @@
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-0.1.2.tgz",
@@ -5223,6 +5214,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {

--- a/tests/jquery.flot.touchNavigate.Test.js
+++ b/tests/jquery.flot.touchNavigate.Test.js
@@ -270,6 +270,46 @@ describe("flot touch navigate plugin", function () {
               expect(yaxis.max).toBeCloseTo(initialYmax - (initialYmax - midPointCoords.y) * (1 - 1/amount), 6);
           });
 
+          it('should zoom the entire plot for touches not on the same axis',function() {
+            plot = $.plot(placeholder, [
+                [
+                    [-1, 2],
+                    [11, 12]
+                ]
+            ], options);
+
+            var eventHolder = plot.getEventHolder(),
+                xaxis = plot.getXAxes()[0],
+                yaxis = plot.getYAxes()[0],
+                initialXmin = xaxis.min,
+                initialXmax = xaxis.max,
+                initialYmin = yaxis.min,
+                initialYmax = yaxis.max,
+                initialCoords = [
+                    { x: xaxis.p2c(4), y: xaxis.box.top + plot.offset().top + 10 },
+                    { x: xaxis.p2c(5), y: xaxis.box.top + plot.offset().top - 10 }
+                ],
+                finalCoords = [
+                    getPairOfCoords(xaxis, yaxis, 2, 4),
+                    getPairOfCoords(xaxis, yaxis, 6, 6)
+                ],
+                midPointCoords = {
+                        x: (xaxis.c2p(finalCoords[0].x - plot.offset().left) + xaxis.c2p(finalCoords[1].x - plot.offset().left)) / 2,
+                        y: (yaxis.c2p(finalCoords[0].y - plot.offset().top) + yaxis.c2p(finalCoords[1].y - plot.offset().top)) / 2
+                },
+                amount = getDistance(finalCoords) / getDistance(initialCoords);
+
+            simulate.sendTouchEvents(initialCoords, eventHolder, 'touchstart');
+            simulate.sendTouchEvents(finalCoords, eventHolder, 'touchmove');
+            simulate.sendTouchEvents(finalCoords, eventHolder, 'touchend');
+
+            expect(xaxis.min).not.toBeCloseTo(initialYmin, 6);
+            expect(xaxis.max).not.toBeCloseTo(initialYmax, 6);
+            expect(yaxis.min).not.toBeCloseTo(initialYmin, 6);
+            expect(yaxis.max).not.toBeCloseTo(initialYmax, 6);
+
+        });
+
         it('should zoom the plot on axis x',function() {
           plot = $.plot(placeholder, [
               [

--- a/tests/jquery.flot.touchNavigate.Test.js
+++ b/tests/jquery.flot.touchNavigate.Test.js
@@ -327,7 +327,7 @@ describe("flot touch navigate plugin", function () {
                 initialYmax = yaxis.max,
                 initialCoords = [
                     { x: xaxis.box.left - 10, y: yaxis.p2c(4) + plot.offset().top},
-                    { x: xaxis.box.left - 20, y: yaxis.p2c(5) + plot.offset().top}
+                    { x: xaxis.box.left - 11, y: yaxis.p2c(5) + plot.offset().top}
                 ],
                 finalCoords = [
                     getPairOfCoords(xaxis, yaxis, 2, 4),
@@ -638,8 +638,64 @@ describe("flot touch navigate plugin", function () {
           expect(xaxis.max).toBeCloseTo(xaxis.c2p(xaxis.p2c(initialXmax) + (pointCoords[0].x - pointCoords[1].x)), 6);
           expect(yaxis.min).toBe(0);
           expect(yaxis.max).toBe(10);
-
       });
+
+      it('should recompute the axis to drag after a pinch event ended',function() {
+          plot = $.plot(placeholder, [
+              [
+                  [-1, 2],
+                  [11, 12]
+              ]
+          ], options);
+
+          var eventHolder = plot.getEventHolder(),
+              xaxis = plot.getXAxes()[0],
+              yaxis = plot.getYAxes()[0],
+              initialXmin = xaxis.min,
+              initialXmax = xaxis.max,
+              initialYmin = yaxis.min,
+              initialYmax = yaxis.max,
+              previousXmin, previousXmax, previousYmin, previousYmax,
+              initialCoords = [
+                  getPairOfCoords(xaxis, yaxis, 1, 3),
+                  getPairOfCoords(xaxis, yaxis, 2, 4),
+              ],
+              midPointCoords = [
+                  getPairOfCoords(xaxis, yaxis, 3, 7),
+                  { x: xaxis.p2c(4), y: xaxis.box.top + plot.offset().top + 10 }
+              ],
+              finalCoordsPinch = [
+                  { x: xaxis.p2c(4), y: xaxis.box.top + plot.offset().top + 10 }
+              ],
+              finalCoordsPan = [
+                  { x: xaxis.p2c(5), y: xaxis.box.top + plot.offset().top + 15 }
+              ];
+
+          //simulate pinch
+          simulate.sendTouchEvents(initialCoords, eventHolder, 'touchstart');
+          simulate.sendTouchEvents(midPointCoords, eventHolder, 'touchmove');
+          simulate.sendTouchEvents(finalCoordsPinch, eventHolder, 'touchend');
+
+          previousXmin = xaxis.min;
+          previousXmax = xaxis.max;
+          previousYmin = yaxis.min;
+          previousYmax = yaxis.max;
+
+          expect(previousXmin).not.toBeCloseTo(initialXmin, 6);
+          expect(previousXmax).not.toBeCloseTo(initialXmax, 6);
+          expect(previousYmin).not.toBeCloseTo(initialYmin, 6);
+          expect(previousYmax).not.toBeCloseTo(initialYmax, 6);
+
+          //simulate pan after pinch event
+          simulate.sendTouchEvents(finalCoordsPan, eventHolder, 'touchmove');
+          simulate.sendTouchEvents(finalCoordsPan, eventHolder, 'touchend');
+
+          expect(xaxis.min).toBeCloseTo(xaxis.c2p(xaxis.p2c(previousXmin) + (finalCoordsPinch[0].x - finalCoordsPan[0].x)), 6);
+          expect(xaxis.max).toBeCloseTo(xaxis.c2p(xaxis.p2c(previousXmax) + (finalCoordsPinch[0].x - finalCoordsPan[0].x)), 6);
+          expect(yaxis.min).toBe(previousYmin);
+          expect(yaxis.max).toBe(previousYmax);
+
+        });
     });
 
     describe('doubleTap', function() {


### PR DESCRIPTION
* In case of pinch, the axis to zoom was computed based on the average of the two touches. This could cause the zooming of a certain axis instead of the hole plot
* when the pinch event is ending, update the list of touched axis for the possibility to continue with a pan (lift just one of the fingers and try to pan with the other one)