### PR TITLE
Extreme zoom, highlight plots on tap and several tests

### DIFF
--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -274,9 +274,8 @@ can set the default in the options.
 
             if (o.zoom.interactive || o.pan.interactive) {
                 eventHolder.dblclick(onDblClick);
+                eventHolder.click(onClick);
             }
-
-            eventHolder.click(onClick);
         }
 
         plot.zoomOut = function(args) {

--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -131,11 +131,9 @@ can set the default in the options.
         var PANHINT_LENGTH_CONSTANT = $.plot.uiConstants.PANHINT_LENGTH_CONSTANT;
 
         function onMouseWheel(e, delta) {
-            if (plot.getOptions().zoom.highlighted) {
-                e.preventDefault();
-                onZoomClick(e, delta < 0);
-                return false;
-            }
+            e.preventDefault();
+            onZoomClick(e, delta < 0);
+            return false;
         }
 
         var prevCursor = 'default',
@@ -163,10 +161,6 @@ can set the default in the options.
         }
 
         function onDragStart(e) {
-            if (!plot.getOptions().pan.highlighted) {
-                return;
-            }
-
             if (e.which !== 1) {
                 // only accept left-click
                 return false;
@@ -198,9 +192,6 @@ can set the default in the options.
         }
 
         function onDrag(e) {
-            if (!plot.getOptions().pan.highlighted) {
-                return;
-            }
             var frameRate = plot.getOptions().pan.frameRate;
 
             if (frameRate === -1) {
@@ -225,10 +216,6 @@ can set the default in the options.
         }
 
         function onDragEnd(e) {
-            if (!plot.getOptions().pan.highlighted) {
-                return;
-            }
-
             if (panTimeout) {
                 clearTimeout(panTimeout);
                 panTimeout = null;
@@ -243,10 +230,7 @@ can set the default in the options.
         }
 
         function onDblClick(e) {
-            var o = plot.getOptions();
-            if (o.pan.highlighted && o.zoom.highlighted) {
-                plot.getPlaceholder().trigger("re-center", e);
-            }
+            plot.getPlaceholder().trigger("re-center", e);
         }
 
         function onClick(e) {
@@ -599,14 +583,6 @@ can set the default in the options.
         plot.hooks.bindEvents.push(bindEvents);
         plot.hooks.shutdown.push(shutdown);
     }
-
-    $(document).on('click touch', function(event) {
-        existingPlots.forEach(function(plot) {
-            var options = plot.getOptions();
-            options.zoom.highlighted = false;
-            options.pan.highlighted = false;
-        });
-    });
 
     $.plot.plugins.push({
         init: init,

--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -87,8 +87,11 @@ can set the default in the options.
 
     var saturated = $.plot.saturated;
 
+    var existingPlots = [];
+
     function init(plot) {
         var panAxes = null;
+        existingPlots.push(plot);
 
         function onZoomClick(e, zoomOut) {
             var c = plot.offset();
@@ -597,6 +600,14 @@ can set the default in the options.
         plot.hooks.bindEvents.push(bindEvents);
         plot.hooks.shutdown.push(shutdown);
     }
+
+    $(document).on('click touch', function(event) {
+        existingPlots.forEach(function(plot) {
+            var options = plot.getOptions();
+            options.zoom.highlighted = false;
+            options.pan.highlighted = false;
+        });
+    });
 
     $.plot.plugins.push({
         init: init,

--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -13,13 +13,13 @@ The plugin supports these options:
 
     zoom: {
         interactive: false,
-        highlighted: false,
+        active: false,
         amount: 1.5         // 2 = 200% (zoom in), 0.5 = 50% (zoom out)
     }
 
     pan: {
         interactive: false,
-        highlighted: false,
+        active: false,
         cursor: "move",     // CSS mouse cursor value used when dragging, e.g. "pointer"
         frameRate: 20,
         mode: "smart"       // enable smart pan mode
@@ -29,8 +29,8 @@ The plugin supports these options:
 interactive for pan, then you'll have a basic plot that supports moving
 around; the same for zoom.
 
-"highlighted" is activated on mouse click or touch tap on plot. This enables
-plot navigation.
+"active" is true after a touch tap on plot. This enables plot navigation.
+Once activated, zoom and pan cannot be deactivated.
 
 "amount" specifies the default amount to zoom in (so 1.5 = 150%) relative to
 the current viewport.
@@ -74,12 +74,12 @@ can set the default in the options.
     var options = {
         zoom: {
             interactive: false,
-            highlighted: false,
+            active: false,
             amount: 1.5 // how much to zoom relative to current position, 2 = 200% (zoom in), 0.5 = 50% (zoom out)
         },
         pan: {
             interactive: false,
-            highlighted: false,
+            active: false,
             cursor: "move",
             frameRate: 60
         }
@@ -87,11 +87,8 @@ can set the default in the options.
 
     var saturated = $.plot.saturated;
 
-    var existingPlots = [];
-
     function init(plot) {
         var panAxes = null;
-        existingPlots.push(plot);
 
         function onZoomClick(e, zoomOut) {
             var c = plot.offset();
@@ -131,9 +128,11 @@ can set the default in the options.
         var PANHINT_LENGTH_CONSTANT = $.plot.uiConstants.PANHINT_LENGTH_CONSTANT;
 
         function onMouseWheel(e, delta) {
-            e.preventDefault();
-            onZoomClick(e, delta < 0);
-            return false;
+            if (plot.getOptions().zoom.active) {
+                e.preventDefault();
+                onZoomClick(e, delta < 0);
+                return false;
+            }
         }
 
         var prevCursor = 'default',
@@ -235,9 +234,9 @@ can set the default in the options.
 
         function onClick(e) {
             var o = plot.getOptions();
-            if (!o.pan.highlighted || !o.zoom.highlighted) {
-                o.pan.highlighted = true;
-                o.zoom.highlighted = true;
+            if (!o.pan.active || !o.zoom.active) {
+                o.pan.active = true;
+                o.zoom.active = true;
             }
             return false;
         }

--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -30,7 +30,7 @@ interactive for pan, then you'll have a basic plot that supports moving
 around; the same for zoom.
 
 "highlighted" is activated on mouse click or touch tap on plot. This enables
-pan and zoom.
+plot navigation.
 
 "amount" specifies the default amount to zoom in (so 1.5 = 150%) relative to
 the current viewport.

--- a/jquery.flot.touch.js
+++ b/jquery.flot.touch.js
@@ -33,6 +33,11 @@
             mainEventHolder;
 
         function interpretGestures(e) {
+            var o = plot.getOptions();
+            if (!o.pan.highlighted || !o.zoom.highlighted) {
+                return;
+            }
+
             if (isPinchEvent(e)) {
                 executeAction(e, 'pinch');
             } else {

--- a/jquery.flot.touch.js
+++ b/jquery.flot.touch.js
@@ -36,7 +36,7 @@
         function interpretGestures(e) {
             var o = plot.getOptions();
 
-            if (!o.pan.highlighted || !o.zoom.highlighted) {
+            if (!o.pan.active || !o.zoom.active) {
                 return;
             }
 
@@ -106,7 +106,9 @@
                 updateCurrentForDoubleTap(e);
                 updateStateForLongTapEnd(e);
 
-                mainEventHolder.dispatchEvent(new CustomEvent('pandrag', { detail: e }));
+                if (!gestureState.allowEventPropagation) {
+                    mainEventHolder.dispatchEvent(new CustomEvent('pandrag', { detail: e }));
+                }
             },
 
             touchend: function(e) {
@@ -129,7 +131,9 @@
             touchmove: function(e) {
                 preventEventPropagation(e);
                 gestureState.twoTouches = isPinchEvent(e);
-                mainEventHolder.dispatchEvent(new CustomEvent('pinchdrag', { detail: e }));
+                if (!gestureState.allowEventPropagation) {
+                    mainEventHolder.dispatchEvent(new CustomEvent('pinchdrag', { detail: e }));
+                }
             },
 
             touchend: function(e) {

--- a/jquery.flot.touch.js
+++ b/jquery.flot.touch.js
@@ -22,6 +22,7 @@
                 prevTap: { x: 0, y: 0 },
                 currentTap: { x: 0, y: 0 },
                 interceptedLongTap: false,
+                allowEventPropagation: false,
                 prevTapTime: null,
                 tapStartTime: null,
                 longTapTriggerId: null
@@ -34,9 +35,12 @@
 
         function interpretGestures(e) {
             var o = plot.getOptions();
+
             if (!o.pan.highlighted || !o.zoom.highlighted) {
                 return;
             }
+
+            updateOnMultipleTouches(e);
 
             if (isPinchEvent(e)) {
                 executeAction(e, 'pinch');
@@ -89,8 +93,6 @@
 
         var pan = {
             touchstart: function(e) {
-                preventEventPropagation(e);
-
                 updatePrevForDoubleTap();
                 updateCurrentForDoubleTap(e);
                 updateStateForLongTapStart(e);
@@ -99,6 +101,8 @@
             },
 
             touchmove: function(e) {
+                preventEventPropagation(e);
+
                 updateCurrentForDoubleTap(e);
                 updateStateForLongTapEnd(e);
 
@@ -107,6 +111,7 @@
 
             touchend: function(e) {
                 preventEventPropagation(e);
+
                 if (wasPinchEvent(e)) {
                     mainEventHolder.dispatchEvent(new CustomEvent('pinchend', { detail: e }));
                     mainEventHolder.dispatchEvent(new CustomEvent('panstart', { detail: e }));
@@ -118,7 +123,6 @@
 
         var pinch = {
             touchstart: function(e) {
-                preventEventPropagation(e);
                 mainEventHolder.dispatchEvent(new CustomEvent('pinchstart', { detail: e }));
             },
 
@@ -235,8 +239,10 @@
         }
 
         function preventEventPropagation(e) {
-            e.preventDefault();
-            e.stopPropagation();
+            if (!gestureState.allowEventPropagation) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
         }
 
         function distance(x1, y1, x2, y2) {
@@ -249,6 +255,14 @@
 
         function wasPinchEvent(e) {
             return (gestureState.twoTouches && e.touches.length === 1);
+        }
+
+        function updateOnMultipleTouches(e) {
+            if (e.touches.length >= 3) {
+                gestureState.allowEventPropagation = true;
+            } else {
+                gestureState.allowEventPropagation = false;
+            }
         }
 
         function isPinchEvent(e) {

--- a/jquery.flot.touchNavigate.js
+++ b/jquery.flot.touchNavigate.js
@@ -29,7 +29,7 @@
                 touchedAxis: null,
                 navigationConstraint: 'unconstrained'
             },
-            pan, pinch, doubleTap, longTap;
+            pan, pinch, doubleTap;
 
         function bindEvents(plot, eventHolder) {
             var o = plot.getOptions();
@@ -42,7 +42,6 @@
                 eventHolder[0].addEventListener('pinchdrag', pinch.drag, false);
                 eventHolder[0].addEventListener('pinchend', pinch.end, false);
                 eventHolder[0].addEventListener('doubletap', doubleTap.recenterPlot, false);
-                eventHolder[0].addEventListener('longtap', longTap.resizeWindow, false);
             }
         }
 
@@ -54,7 +53,6 @@
             eventHolder[0].removeEventListener('pinchdrag', pinch.drag);
             eventHolder[0].removeEventListener('pinchend', pinch.end);
             eventHolder[0].removeEventListener('doubletap', doubleTap.recenterPlot);
-            eventHolder[0].removeEventListener('longtap', longTap.resizeWindow);
         }
 
         pan = {
@@ -119,12 +117,6 @@
             }
         };
 
-        longTap = {
-            resizeWindow: function(e) {
-                resizeWindowOnLongTap();
-            }
-        };
-
         if (options.pan.enableTouch === true) {
             plot.hooks.bindEvents.push(bindEvents);
             plot.hooks.shutdown.push(shutdown);
@@ -146,10 +138,6 @@
         name: 'navigateTouch',
         version: '0.3'
     });
-
-    function resizeWindowOnLongTap() {
-  
-    }
 
     function recenterPlotOnDoubleTap(plot, e, gestureState, navigationState) {
         checkAxesForDoubleTap(plot, e, navigationState);

--- a/jquery.flot.touchNavigate.js
+++ b/jquery.flot.touchNavigate.js
@@ -29,7 +29,7 @@
                 touchedAxis: null,
                 navigationConstraint: 'unconstrained'
             },
-            pan, pinch, doubleTap;
+            pan, pinch, doubleTap, longTap;
 
         function bindEvents(plot, eventHolder) {
             var o = plot.getOptions();
@@ -42,6 +42,7 @@
                 eventHolder[0].addEventListener('pinchdrag', pinch.drag, false);
                 eventHolder[0].addEventListener('pinchend', pinch.end, false);
                 eventHolder[0].addEventListener('doubletap', doubleTap.recenterPlot, false);
+                eventHolder[0].addEventListener('longtap', longTap.resizeWindow, false);
             }
         }
 
@@ -53,6 +54,7 @@
             eventHolder[0].removeEventListener('pinchdrag', pinch.drag);
             eventHolder[0].removeEventListener('pinchend', pinch.end);
             eventHolder[0].removeEventListener('doubletap', doubleTap.recenterPlot);
+            eventHolder[0].removeEventListener('longtap', longTap.resizeWindow);
         }
 
         pan = {
@@ -117,6 +119,12 @@
             }
         };
 
+        longTap = {
+            resizeWindow: function(e) {
+                resizeWindowOnLongTap();
+            }
+        };
+
         if (options.pan.enableTouch === true) {
             plot.hooks.bindEvents.push(bindEvents);
             plot.hooks.shutdown.push(shutdown);
@@ -138,6 +146,10 @@
         name: 'navigateTouch',
         version: '0.3'
     });
+
+    function resizeWindowOnLongTap() {
+  
+    }
 
     function recenterPlotOnDoubleTap(plot, e, gestureState, navigationState) {
         checkAxesForDoubleTap(plot, e, navigationState);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -44,7 +44,7 @@ module.exports = function(config) {
         // list of files / patterns to load in the browser
         files: sources.concat([
             'node_modules/phantomjs-polyfill-find/find-polyfill.js',
-            'node_modules/webcharts-development-settings/tests/utils/*.js',
+            'node_modules/webcharts-development-settings/testsUtils/utils/*.js',
             'tests/*.Test.js'
         ]),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5163,15 +5163,6 @@
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-0.1.2.tgz",
@@ -5223,6 +5214,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {
@@ -5647,9 +5647,9 @@
       "dev": true
     },
     "webcharts-development-settings": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/webcharts-development-settings/-/webcharts-development-settings-0.0.4.tgz",
-      "integrity": "sha512-dGmbJzKwAFJ8KPfjhK1oeg2UJDgCTVvWqP2d8vYzMF0VYGB75RUhp3eN7DDuRgo4Bwv9X49sEIuV1hrZYWCf/Q==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/webcharts-development-settings/-/webcharts-development-settings-0.0.5.tgz",
+      "integrity": "sha512-1YzKYoHeEJFizfpq9GlNpmgTR6b9SJgSwfIqj2y7QRqki3KgDTUX4FsL1TmkE6NHyKaO5TEQlKfNghOHvWeKBQ==",
       "dev": true,
       "requires": {
         "eslint-config-standard": "7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5647,9 +5647,9 @@
       "dev": true
     },
     "webcharts-development-settings": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/webcharts-development-settings/-/webcharts-development-settings-0.0.5.tgz",
-      "integrity": "sha512-1YzKYoHeEJFizfpq9GlNpmgTR6b9SJgSwfIqj2y7QRqki3KgDTUX4FsL1TmkE6NHyKaO5TEQlKfNghOHvWeKBQ==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/webcharts-development-settings/-/webcharts-development-settings-0.0.7.tgz",
+      "integrity": "sha512-7iy2asRmO+s4AldsmYz8pkl81XtTcGjn+tTbflAhti9pB28vy3bwvtAIvgWQFBp5tViXuASF1dzmU1vr4z5b8Q==",
       "dev": true,
       "requires": {
         "eslint-config-standard": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "karma-spec-reporter": "0.0.31",
     "phantomjs-polyfill-find": "0.0.1",
     "tmp": "0.0.33",
-    "webcharts-development-settings": "0.0.5"
+    "webcharts-development-settings": "0.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "karma-spec-reporter": "0.0.31",
     "phantomjs-polyfill-find": "0.0.1",
     "tmp": "0.0.33",
-    "webcharts-development-settings": "0.0.4"
+    "webcharts-development-settings": "0.0.5"
   }
 }

--- a/tests/jquery.flot.navigate-interaction.Test.js
+++ b/tests/jquery.flot.navigate-interaction.Test.js
@@ -14,12 +14,12 @@ describe("flot navigate plugin interactions", function () {
         }],
         zoom: {
             interactive: true,
-            highlighted: true,
+            active: true,
             amount: 10
         },
         pan: {
             interactive: true,
-            highlighted: true
+            active: true
         }
     };
 

--- a/tests/jquery.flot.navigate-interaction.Test.js
+++ b/tests/jquery.flot.navigate-interaction.Test.js
@@ -14,10 +14,12 @@ describe("flot navigate plugin interactions", function () {
         }],
         zoom: {
             interactive: true,
+            highlighted: true,
             amount: 10
         },
         pan: {
-            interactive: true
+            interactive: true,
+            highlighted: true
         }
     };
 
@@ -142,9 +144,11 @@ describe("flot navigate plugin interactions", function () {
         }],
         zoom: {
             interactive: false,
+            highlighted: true
         },
         pan: {
-            interactive: true
+            interactive: true,
+            highlighted: true
         },
         selection: {
             mode: 'smart',

--- a/tests/jquery.flot.navigate.Test.js
+++ b/tests/jquery.flot.navigate.Test.js
@@ -10,8 +10,8 @@ describe("flot navigate plugin", function () {
         options = {
             xaxes: [{ autoscale: 'exact' }],
             yaxes: [{ autoscale: 'exact' }],
-            zoom: { interactive: true, amount: 10 },
-            pan: { interactive: true, frameRate: -1 }
+            zoom: { interactive: true, highlighted: true, amount: 10 },
+            pan: { interactive: true, highlighted: true, frameRate: -1 }
         };
     });
 
@@ -227,6 +227,47 @@ describe("flot navigate plugin", function () {
             expect(ticks[middle + 1].v).toBe(4);
 
         });
+
+        it('does not zoom for highlighted false', function () {
+            plot = $.plot(placeholder, [
+                [
+                    [0, 0],
+                    [10, 10]
+                ]
+            ], {
+                xaxes: [{ autoscale: 'exact' }],
+                yaxes: [{ autoscale: 'exact' }],
+                zoom: { interactive: true, highlighted: false, amount: 10 },
+                pan: { interactive: true, highlighted: false, frameRate: -1 }
+            });
+
+            var eventHolder = plot.getEventHolder(),
+                xaxis = plot.getXAxes()[0],
+                yaxis = plot.getYAxes()[0],
+                initialCoords = [
+                    {x: 3, y: 5},
+                    {x:7, y:9}
+                ],
+                finalCoords = [
+                    {x: 2, y: 4},
+                    {x: 8, y: 10}
+                ],
+                midPointCoords = {
+                    x: (xaxis.c2p(finalCoords[0].x - plot.offset().left) + xaxis.c2p(finalCoords[1].x - plot.offset().left)) / 2,
+                    y: (yaxis.c2p(finalCoords[0].y - plot.offset().top) + yaxis.c2p(finalCoords[1].y - plot.offset().top)) / 2
+                };
+
+            simulate.sendTouchEvents(initialCoords, eventHolder, 'touchstart');
+            simulate.sendTouchEvents(finalCoords, eventHolder, 'touchmove');
+            simulate.sendTouchEvents(finalCoords, eventHolder, 'touchend');
+
+            expect(xaxis.min).toBe(0);
+            expect(xaxis.max).toBe(10);
+            expect(yaxis.min).toBe(0);
+            expect(yaxis.max).toBe(10);
+
+        });
+
 
         describe('with large numbers', function() {
             it ('limits the navigation offsets', function () {
@@ -551,8 +592,8 @@ describe("flot navigate plugin", function () {
             ], {
                 xaxes: [{ autoscale: 'exact', mode : 'log'}],
                 yaxes: [{ autoscale: 'exact' }],
-                zoom: { interactive: true, amount: 10 },
-                pan: { interactive: true, frameRate: -1 }
+                zoom: { interactive: true, highlighted: true, amount: 10 },
+                pan: { interactive: true, highlighted: true, frameRate: -1 }
             });
 
             xaxis = plot.getXAxes()[0];
@@ -599,6 +640,39 @@ describe("flot navigate plugin", function () {
     });
 
     describe('mousePan', function() {
+        it('does not pan for highlighted false', function(){
+            plot = $.plot(placeholder, [
+                [
+                    [0, 0],
+                    [10, 10]
+                ]
+            ], {
+                xaxes: [{ autoscale: 'exact' }],
+                yaxes: [{ autoscale: 'exact' }],
+                zoom: { interactive: true, highlighted: false, amount: 10 },
+                pan: { interactive: true, highlighted: false, frameRate: -1 }
+            });
+
+            var xaxis = plot.getXAxes()[0],
+                yaxis = plot.getYAxes()[0],
+                eventHolder = plot.getEventHolder(),
+                pointCoords = [
+                    { x: 10, y: 50 },
+                    { x: 20, y: plot.height() }
+                ];
+
+            simulate.mouseDown(eventHolder, pointCoords[0].x, pointCoords[0].y);
+            simulate.mouseMove(eventHolder, pointCoords[0].x, pointCoords[0].y);
+            simulate.mouseMove(eventHolder, pointCoords[1].x, pointCoords[1].y);
+            simulate.mouseUp(eventHolder, pointCoords[1].x, pointCoords[1].y);
+
+            expect(xaxis.min).toBe(0);
+            expect(xaxis.max).toBe(10);
+            expect(yaxis.min).toBe(0);
+            expect(yaxis.max).toBe(10);
+
+        });
+
         it ('pans on xaxis only', function () {
             plot = $.plot(placeholder, [
                 [
@@ -613,8 +687,8 @@ describe("flot navigate plugin", function () {
                 initialXmax = xaxis.max,
                 eventHolder = plot.getEventHolder(),
                 pointCoords = [
-                        { x: xaxis.p2c(4), y: xaxis.box.top + plot.offset().top + 10 },
-                        { x: xaxis.p2c(5), y: xaxis.box.top + plot.offset().top + 15 }
+                    { x: xaxis.p2c(4), y: xaxis.box.top + plot.offset().top + 10 },
+                    { x: xaxis.p2c(5), y: xaxis.box.top + plot.offset().top + 15 }
                 ];
 
             simulate.mouseDown(eventHolder, pointCoords[0].x, pointCoords[0].y);
@@ -657,6 +731,28 @@ describe("flot navigate plugin", function () {
             expect(yaxis.min).toBeCloseTo(yaxis.c2p(yaxis.p2c(initialYmin) + (pointCoords[0].y - pointCoords[1].y)), 0);
             expect(yaxis.max).toBeCloseTo(yaxis.c2p(yaxis.p2c(initialYmax) + (pointCoords[0].y - pointCoords[1].y)), 0);
 
+        });
+    });
+
+    describe('mouse click', function(){
+        it('on plot enables zoom and pan highlighted', function() {
+            plot = $.plot(placeholder, [
+                [
+                    [0, 0],
+                    [10, 10]
+                ]
+              ], {
+                  zoom: { interactive: true, highlighted: false, amount: 10 },
+                  pan: { interactive: true, highlighted: false}
+              });
+
+              var eventHolder = plot.getEventHolder(),
+                  pointCoords = { x: 0, y: plot.height() };
+
+              simulate.click(eventHolder, pointCoords.x, pointCoords.y);
+
+              expect(plot.getOptions().pan.highlighted).toBe(true);
+              expect(plot.getOptions().zoom.highlighted).toBe(true);
         });
     });
 });

--- a/tests/jquery.flot.navigate.Test.js
+++ b/tests/jquery.flot.navigate.Test.js
@@ -735,7 +735,7 @@ describe("flot navigate plugin", function () {
     });
 
     describe('mouse click', function(){
-        it('on plot enables zoom and pan highlighted', function() {
+        it('on plot activates plot\'s zoom and pan highlighted propriety', function() {
             plot = $.plot(placeholder, [
                 [
                     [0, 0],

--- a/tests/jquery.flot.navigate.Test.js
+++ b/tests/jquery.flot.navigate.Test.js
@@ -10,8 +10,8 @@ describe("flot navigate plugin", function () {
         options = {
             xaxes: [{ autoscale: 'exact' }],
             yaxes: [{ autoscale: 'exact' }],
-            zoom: { interactive: true, highlighted: true, amount: 10 },
-            pan: { interactive: true, highlighted: true, frameRate: -1 }
+            zoom: { interactive: true, active: true, amount: 10 },
+            pan: { interactive: true, active: true, frameRate: -1 }
         };
     });
 
@@ -228,7 +228,7 @@ describe("flot navigate plugin", function () {
 
         });
 
-        it('does not zoom for highlighted false', function () {
+        it('does not zoom for active false', function () {
             plot = $.plot(placeholder, [
                 [
                     [0, 0],
@@ -237,8 +237,8 @@ describe("flot navigate plugin", function () {
             ], {
                 xaxes: [{ autoscale: 'exact' }],
                 yaxes: [{ autoscale: 'exact' }],
-                zoom: { interactive: true, highlighted: false, amount: 10 },
-                pan: { interactive: true, highlighted: false, frameRate: -1 }
+                zoom: { interactive: true, active: false, amount: 10 },
+                pan: { interactive: true, active: false, frameRate: -1 }
             });
 
             var eventHolder = plot.getEventHolder(),
@@ -592,8 +592,8 @@ describe("flot navigate plugin", function () {
             ], {
                 xaxes: [{ autoscale: 'exact', mode : 'log'}],
                 yaxes: [{ autoscale: 'exact' }],
-                zoom: { interactive: true, highlighted: true, amount: 10 },
-                pan: { interactive: true, highlighted: true, frameRate: -1 }
+                zoom: { interactive: true, active: true, amount: 10 },
+                pan: { interactive: true, active: true, frameRate: -1 }
             });
 
             xaxis = plot.getXAxes()[0];
@@ -702,15 +702,15 @@ describe("flot navigate plugin", function () {
     });
 
     describe('mouse click', function(){
-        it('on plot activates plot\'s zoom and pan highlighted propriety', function() {
+        it('on plot activates plot\'s zoom and pan active propriety', function() {
             plot = $.plot(placeholder, [
                 [
                     [0, 0],
                     [10, 10]
                 ]
               ], {
-                  zoom: { interactive: true, highlighted: false, amount: 10 },
-                  pan: { interactive: true, highlighted: false}
+                  zoom: { interactive: true, active: false, amount: 10 },
+                  pan: { interactive: true, active: false}
               });
 
               var eventHolder = plot.getEventHolder(),
@@ -718,8 +718,8 @@ describe("flot navigate plugin", function () {
 
               simulate.click(eventHolder, pointCoords.x, pointCoords.y);
 
-              expect(plot.getOptions().pan.highlighted).toBe(true);
-              expect(plot.getOptions().zoom.highlighted).toBe(true);
+              expect(plot.getOptions().pan.active).toBe(true);
+              expect(plot.getOptions().zoom.active).toBe(true);
         });
     });
 });

--- a/tests/jquery.flot.navigate.Test.js
+++ b/tests/jquery.flot.navigate.Test.js
@@ -640,39 +640,6 @@ describe("flot navigate plugin", function () {
     });
 
     describe('mousePan', function() {
-        it('does not pan for highlighted false', function(){
-            plot = $.plot(placeholder, [
-                [
-                    [0, 0],
-                    [10, 10]
-                ]
-            ], {
-                xaxes: [{ autoscale: 'exact' }],
-                yaxes: [{ autoscale: 'exact' }],
-                zoom: { interactive: true, highlighted: false, amount: 10 },
-                pan: { interactive: true, highlighted: false, frameRate: -1 }
-            });
-
-            var xaxis = plot.getXAxes()[0],
-                yaxis = plot.getYAxes()[0],
-                eventHolder = plot.getEventHolder(),
-                pointCoords = [
-                    { x: 10, y: 50 },
-                    { x: 20, y: plot.height() }
-                ];
-
-            simulate.mouseDown(eventHolder, pointCoords[0].x, pointCoords[0].y);
-            simulate.mouseMove(eventHolder, pointCoords[0].x, pointCoords[0].y);
-            simulate.mouseMove(eventHolder, pointCoords[1].x, pointCoords[1].y);
-            simulate.mouseUp(eventHolder, pointCoords[1].x, pointCoords[1].y);
-
-            expect(xaxis.min).toBe(0);
-            expect(xaxis.max).toBe(10);
-            expect(yaxis.min).toBe(0);
-            expect(yaxis.max).toBe(10);
-
-        });
-
         it ('pans on xaxis only', function () {
             plot = $.plot(placeholder, [
                 [
@@ -753,34 +720,6 @@ describe("flot navigate plugin", function () {
 
               expect(plot.getOptions().pan.highlighted).toBe(true);
               expect(plot.getOptions().zoom.highlighted).toBe(true);
-        });
-
-        it('outside plot deactivates plot\'s zoom and pan highlighted propriety', function() {
-            var pointCoords = { x: 0, y: 10 },
-                outsideContainer = setFixtures('<div id="container" style="width: 10px;height: 20px">')
-                    .find('#container');
-
-            plot = $.plot(placeholder, [
-                [
-                    [0, 0],
-                    [10, 10]
-                ]
-              ], {
-                  zoom: { interactive: true, highlighted: true, amount: 10 },
-                  pan: { interactive: true, highlighted: true}
-              });
-
-              outsideContainer.getBoundingClientRect = function() {
-                  return {left: 0, top: 0};
-              };
-              outsideContainer.dispatchEvent = function(evt) {
-                  document.dispatchEvent(evt);
-              };
-              simulate.click(outsideContainer, pointCoords.x, pointCoords.y);
-
-
-              expect(plot.getOptions().pan.highlighted).toBe(false);
-              expect(plot.getOptions().zoom.highlighted).toBe(false);
         });
     });
 });

--- a/tests/jquery.flot.navigate.Test.js
+++ b/tests/jquery.flot.navigate.Test.js
@@ -754,5 +754,30 @@ describe("flot navigate plugin", function () {
               expect(plot.getOptions().pan.highlighted).toBe(true);
               expect(plot.getOptions().zoom.highlighted).toBe(true);
         });
+
+        xit('outside plot deactivates plot\'s zoom and pan highlighted propriety', function() {
+            var pointCoords = { x: 0, y: 10 },
+                outsideContainer = setFixtures('<div id="container" style="width: 10px;height: 20px">')
+                    .find('#container');
+
+            plot = $.plot(placeholder, [
+                [
+                    [0, 0],
+                    [10, 10]
+                ]
+              ], {
+                  zoom: { interactive: true, highlighted: true, amount: 10 },
+                  pan: { interactive: true, highlighted: true}
+              });
+
+              outsideContainer.getBoundingClientRect = function() {
+                  return {left: 0, top: 0};
+              };
+              simulate.click(outsideContainer, pointCoords.x, pointCoords.y);
+
+
+              expect(plot.getOptions().pan.highlighted).toBe(false);
+              expect(plot.getOptions().zoom.highlighted).toBe(false);
+        });
     });
 });

--- a/tests/jquery.flot.navigate.Test.js
+++ b/tests/jquery.flot.navigate.Test.js
@@ -755,7 +755,7 @@ describe("flot navigate plugin", function () {
               expect(plot.getOptions().zoom.highlighted).toBe(true);
         });
 
-        xit('outside plot deactivates plot\'s zoom and pan highlighted propriety', function() {
+        it('outside plot deactivates plot\'s zoom and pan highlighted propriety', function() {
             var pointCoords = { x: 0, y: 10 },
                 outsideContainer = setFixtures('<div id="container" style="width: 10px;height: 20px">')
                     .find('#container');
@@ -772,6 +772,9 @@ describe("flot navigate plugin", function () {
 
               outsideContainer.getBoundingClientRect = function() {
                   return {left: 0, top: 0};
+              };
+              outsideContainer.dispatchEvent = function(evt) {
+                  document.dispatchEvent(evt);
               };
               simulate.click(outsideContainer, pointCoords.x, pointCoords.y);
 

--- a/tests/jquery.flot.touch.Test.js
+++ b/tests/jquery.flot.touch.Test.js
@@ -297,4 +297,87 @@ describe("flot touch plugin", function () {
             expect(spy.calls.count()).toBe(0);
         });
     });
+
+    describe('doubletap', function() {
+
+        beforeEach(function() {
+            jasmine.clock().install().mockDate();
+        });
+
+        afterEach(function() {
+            jasmine.clock().uninstall();
+        });
+
+        it('should trigger the double tap event', function() {
+            plot = $.plot(placeholder, [[]], options);
+
+            var eventHolder = plot.getEventHolder(),
+                spy = jasmine.createSpy('double tap handler'),
+                coords = [{x: 10, y: 20}];
+
+            eventHolder.addEventListener('doubletap', spy);
+
+            simulate.sendTouchEvents(coords, eventHolder, 'touchstart');
+            jasmine.clock().tick(200);
+            simulate.sendTouchEvents(coords, eventHolder, 'touchstart');
+
+            expect(spy).toHaveBeenCalled();
+            expect(spy.calls.count()).toBe(1);
+        });
+
+        it('should trigger the double tap event even when there is a different touch point', function() {
+            plot = $.plot(placeholder, [[]], options);
+
+            var eventHolder = plot.getEventHolder(),
+                spy = jasmine.createSpy('double tap handler'),
+                initialCoords = [{x: 10, y: 20}],
+                finalCoords = [{x: 11, y: 21}];
+
+            eventHolder.addEventListener('doubletap', spy);
+
+            simulate.sendTouchEvents(initialCoords, eventHolder, 'touchstart');
+            jasmine.clock().tick(300);
+            simulate.sendTouchEvents(finalCoords, eventHolder, 'touchstart');
+
+            expect(spy).toHaveBeenCalled();
+            expect(spy.calls.count()).toBe(1);
+        });
+
+        it('should not trigger the double tap event for a big interval between taps', function() {
+            plot = $.plot(placeholder, [[]], options);
+
+            var eventHolder = plot.getEventHolder(),
+                spy = jasmine.createSpy('double tap handler'),
+                coords = [{x: 10, y: 20}];
+
+            eventHolder.addEventListener('doubletap', spy);
+
+            simulate.sendTouchEvents(coords, eventHolder, 'touchstart');
+            jasmine.clock().tick(1000);
+            simulate.sendTouchEvents(coords, eventHolder, 'touchstart');
+
+            expect(spy).not.toHaveBeenCalled();
+            expect(spy.calls.count()).toBe(0);
+        });
+
+        it('should not trigger the double tap event for one of the touches outside plot area', function() {
+            plot = $.plot(placeholder, [[]], options);
+
+            var eventHolder = plot.getEventHolder(),
+                mockEventHolder = {},
+                spy = jasmine.createSpy('double tap handler'),
+                initialCoords = [{x: 10, y: 20}],
+                finalCoords = [{x: 100, y: 200}];
+
+            mockEventHolder.dispatchEvent = function() {};
+
+            eventHolder.addEventListener('doubletap', spy);
+
+            simulate.sendTouchEvents(initialCoords, eventHolder, 'touchstart');
+            jasmine.clock().tick(100);
+            simulate.sendTouchEvents(finalCoords, mockEventHolder, 'touchmove');
+
+            expect(spy).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/tests/jquery.flot.touch.Test.js
+++ b/tests/jquery.flot.touch.Test.js
@@ -10,8 +10,8 @@ describe("flot touch plugin", function () {
         options = {
             xaxes: [{ autoscale: 'exact' }],
             yaxes: [{ autoscale: 'exact' }],
-            zoom: { interactive: true, amount: 10, highlighted: true },
-            pan: { interactive: true, frameRate: -1, enableTouch: true, highlighted: true }
+            zoom: { interactive: true, amount: 10, active: true },
+            pan: { interactive: true, frameRate: -1, enableTouch: true, active: true }
         };
     });
 
@@ -170,7 +170,7 @@ describe("flot touch plugin", function () {
             expect(spy.calls.count()).toBe(1);
         });
 
-        it('should not trigger pinch event for highlighted false',function() {
+        it('should not trigger pinch event for plot not active',function() {
             plot = $.plot(placeholder, [
                 [
                     [0, 0],
@@ -179,8 +179,8 @@ describe("flot touch plugin", function () {
                 ], {
                 xaxes: [{ autoscale: 'exact' }],
                 yaxes: [{ autoscale: 'exact' }],
-                zoom: { interactive: true, highlighted: false, amount: 10 },
-                pan: { interactive: true, highlighted: false, frameRate: -1 }
+                zoom: { interactive: true, active: false, amount: 10 },
+                pan: { interactive: true, active: false, frameRate: -1 }
             });
 
             var eventHolder = plot.getEventHolder(),
@@ -275,7 +275,7 @@ describe("flot touch plugin", function () {
             expect(spy.calls.count()).toBe(1);
         });
 
-        it('should not trigger pan event for highlighted false',function() {
+        it('should not trigger pan event for plot not active',function() {
             plot = $.plot(placeholder, [
                 [
                     [0, 0],
@@ -284,8 +284,8 @@ describe("flot touch plugin", function () {
                 ], {
                 xaxes: [{ autoscale: 'exact' }],
                 yaxes: [{ autoscale: 'exact' }],
-                zoom: { interactive: true, highlighted: false, amount: 10 },
-                pan: { interactive: true, highlighted: false, frameRate: -1 }
+                zoom: { interactive: true, active: false, amount: 10 },
+                pan: { interactive: true, active: false, frameRate: -1 }
             });
 
             var eventHolder = plot.getEventHolder(),

--- a/tests/jquery.flot.touch.Test.js
+++ b/tests/jquery.flot.touch.Test.js
@@ -227,6 +227,27 @@ describe("flot touch plugin", function () {
             expect(spy).not.toHaveBeenCalled();
             expect(spy.calls.count()).toBe(0);
         });
+
+        it('allows default propagation for three touches',function() {
+            plot = $.plot(placeholder, [], options);
+
+            var eventHolder = plot.getEventHolder(),
+                touchCoords = [{pageX: 10, pageY: 20}, {pageX: 15, pageY: 20}, {pageX: 20, pageY: 25}],
+                touchStartEvent = new CustomEvent('touchstart'),
+                touchMoveEvent = new CustomEvent('touchmove');
+
+            touchStartEvent.touches = touchCoords;
+            touchStartEvent.preventDefault = jasmine.createSpy();
+            touchMoveEvent.touches = touchCoords;
+            touchMoveEvent.preventDefault = jasmine.createSpy();
+
+            eventHolder.dispatchEvent(touchStartEvent);
+            eventHolder.dispatchEvent(touchMoveEvent);
+
+            expect(touchStartEvent.preventDefault).not.toHaveBeenCalled();
+            expect(touchMoveEvent.preventDefault).not.toHaveBeenCalled();
+
+        });
     });
 
     describe('pan', function() {

--- a/tests/jquery.flot.touch.Test.js
+++ b/tests/jquery.flot.touch.Test.js
@@ -10,8 +10,8 @@ describe("flot touch plugin", function () {
         options = {
             xaxes: [{ autoscale: 'exact' }],
             yaxes: [{ autoscale: 'exact' }],
-            zoom: { interactive: true, amount: 10 },
-            pan: { interactive: true, frameRate: -1, enableTouch: true }
+            zoom: { interactive: true, amount: 10, highlighted: true },
+            pan: { interactive: true, frameRate: -1, enableTouch: true, highlighted: true }
         };
     });
 
@@ -170,6 +170,31 @@ describe("flot touch plugin", function () {
             expect(spy.calls.count()).toBe(1);
         });
 
+        it('should not trigger pinch event for highlighted false',function() {
+            plot = $.plot(placeholder, [
+                [
+                    [0, 0],
+                    [10, 10]
+                ]
+                ], {
+                xaxes: [{ autoscale: 'exact' }],
+                yaxes: [{ autoscale: 'exact' }],
+                zoom: { interactive: true, highlighted: false, amount: 10 },
+                pan: { interactive: true, highlighted: false, frameRate: -1 }
+            });
+
+            var eventHolder = plot.getEventHolder(),
+                spy = jasmine.createSpy('pinch handler'),
+                coords = [{x: 10, y: 20}, {x: 15, y: 20}];
+
+            eventHolder.addEventListener('pinchstart', spy);
+
+            simulate.sendTouchEvents(coords, eventHolder, 'touchstart');
+
+            expect(spy).not.toHaveBeenCalled();
+            expect(spy.calls.count()).toBe(0);
+        });
+
         it('should not trigger pinch event for only one touch',function() {
             plot = $.plot(placeholder, [[]], options);
 
@@ -191,9 +216,78 @@ describe("flot touch plugin", function () {
             var eventHolder = plot.getEventHolder(),
                 mockEventHolder = {},
                 spy = jasmine.createSpy('pinch handler'),
-                coords = [{x: 10, y: 20}];
+                coords = [{x: 10, y: 20}, {x: 15, y: 20}];
 
             eventHolder.addEventListener('pinchstart', spy);
+
+            mockEventHolder.dispatchEvent = function() {};
+
+            simulate.sendTouchEvents(coords, mockEventHolder, 'touchstart');
+
+            expect(spy).not.toHaveBeenCalled();
+            expect(spy.calls.count()).toBe(0);
+        });
+    });
+
+    describe('pan', function() {
+
+        beforeEach(function() {
+            jasmine.clock().install().mockDate();
+        });
+
+        afterEach(function() {
+            jasmine.clock().uninstall();
+        });
+
+        it('should be able to trigger pan event',function() {
+            plot = $.plot(placeholder, [[]], options);
+
+            var eventHolder = plot.getEventHolder(),
+                spy = jasmine.createSpy('pan handler'),
+                coords = [{x: 10, y: 20}];
+
+            eventHolder.addEventListener('pan', spy);
+
+            simulate.sendTouchEvents(coords, eventHolder, 'pan');
+
+            expect(spy).toHaveBeenCalled();
+            expect(spy.calls.count()).toBe(1);
+        });
+
+        it('should not trigger pan event for highlighted false',function() {
+            plot = $.plot(placeholder, [
+                [
+                    [0, 0],
+                    [10, 10]
+                ]
+                ], {
+                xaxes: [{ autoscale: 'exact' }],
+                yaxes: [{ autoscale: 'exact' }],
+                zoom: { interactive: true, highlighted: false, amount: 10 },
+                pan: { interactive: true, highlighted: false, frameRate: -1 }
+            });
+
+            var eventHolder = plot.getEventHolder(),
+                spy = jasmine.createSpy('pan handler'),
+                coords = [{x: 10, y: 20}];
+
+            eventHolder.addEventListener('pan', spy);
+
+            simulate.sendTouchEvents(coords, eventHolder, 'touchstart');
+
+            expect(spy).not.toHaveBeenCalled();
+            expect(spy.calls.count()).toBe(0);
+        });
+
+        it('should not trigger pan event for touch outside plot',function() {
+            plot = $.plot(placeholder, [[]], options);
+
+            var eventHolder = plot.getEventHolder(),
+                mockEventHolder = {},
+                spy = jasmine.createSpy('pan handler'),
+                coords = [{x: 10, y: 20}];
+
+            eventHolder.addEventListener('panstart', spy);
 
             mockEventHolder.dispatchEvent = function() {};
 

--- a/tests/jquery.flot.touchNavigate.Test.js
+++ b/tests/jquery.flot.touchNavigate.Test.js
@@ -780,6 +780,51 @@ describe("flot touch navigate plugin", function () {
           expect(yaxis.max).toBeCloseTo(initialYmax, 6);
 
         });
+
+        it('should not recenter the plot for one touch inside axis box and one inside plot area', function(){
+            plot = $.plot(placeholder, [
+                [
+                    [-10, -10],
+                    [120, 120]
+                ]
+            ], options);
+
+            var eventHolder = plot.getEventHolder(),
+                xaxis = plot.getXAxes()[0],
+                yaxis = plot.getYAxes()[0],
+                initialXmin = xaxis.min,
+                initialXmax = xaxis.max,
+                initialYmin = yaxis.min,
+                initialYmax = yaxis.max,
+                canvasCoords = [ { x : 1, y : 2 }, { x : 3, y : 5 }],
+                pointCoords = [
+                    getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
+                    getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y)
+                ];
+
+            simulate.touchstart(eventHolder, pointCoords[0].x, pointCoords[0].y);
+            simulate.touchmove(eventHolder, pointCoords[1].x, pointCoords[1].y);
+            simulate.touchend(eventHolder, pointCoords[1].x, pointCoords[1].y);
+
+            //check if the drag modified the plot correctly
+            expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[1].x), 6);
+            expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
+            expect(yaxis.min).toBeCloseTo(initialYmin + (canvasCoords[0].y - canvasCoords[1].y), 6);
+            expect(yaxis.max).toBeCloseTo(initialYmax + (canvasCoords[0].y - canvasCoords[1].y), 6);
+
+            //simulate double tap
+            simulate.touchstart(eventHolder, xaxis.box.left - 20, yaxis.p2c(5));
+            simulate.touchend(eventHolder,  xaxis.box.left - 20, yaxis.p2c(5));
+            simulate.touchstart(eventHolder, 10, 20);
+            simulate.touchend(eventHolder, 10, 20);
+
+            //check if axis values remained the same
+            expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[1].x), 6);
+            expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[1].x), 6);
+            expect(yaxis.min).toBeCloseTo(initialYmin + (canvasCoords[0].y - canvasCoords[1].y), 6);
+            expect(yaxis.max).toBeCloseTo(initialYmax + (canvasCoords[0].y - canvasCoords[1].y), 6);
+
+        });
     });
 
     function getPairOfCoords(xaxis, yaxis, x, y) {

--- a/tests/jquery.flot.touchNavigate.Test.js
+++ b/tests/jquery.flot.touchNavigate.Test.js
@@ -10,8 +10,8 @@ describe("flot touch navigate plugin", function () {
         options = {
             xaxes: [{ autoscale: 'exact' }],
             yaxes: [{ autoscale: 'exact' }],
-            zoom: { interactive: true, amount: 10 },
-            pan: { interactive: true, frameRate: -1, enableTouch: true }
+            zoom: { interactive: true, highlighted: true, amount: 10 },
+            pan: { interactive: true, highlighted: true, frameRate: -1, enableTouch: true }
         };
     });
 
@@ -402,8 +402,8 @@ describe("flot touch navigate plugin", function () {
               },
               xaxis: { autoscale: 'exact' },
               yaxis: { mode: 'log', showTickLabels: "all", autoscale: 'exact' },
-              zoom: { interactive: true },
-              pan: { interactive: true, enableTouch: true }
+              zoom: { interactive: true, highlighted: true },
+              pan: { interactive: true, highlighted: true, enableTouch: true }
           });
 
           var eventHolder = plot.getEventHolder(),

--- a/tests/jquery.flot.touchNavigate.Test.js
+++ b/tests/jquery.flot.touchNavigate.Test.js
@@ -10,8 +10,8 @@ describe("flot touch navigate plugin", function () {
         options = {
             xaxes: [{ autoscale: 'exact' }],
             yaxes: [{ autoscale: 'exact' }],
-            zoom: { interactive: true, highlighted: true, amount: 10 },
-            pan: { interactive: true, highlighted: true, frameRate: -1, enableTouch: true }
+            zoom: { interactive: true, active: true, amount: 10 },
+            pan: { interactive: true, active: true, frameRate: -1, enableTouch: true }
         };
     });
 
@@ -60,95 +60,6 @@ describe("flot touch navigate plugin", function () {
                 amount = getDistance(finalCoords) / getDistance(initialCoords);
 
             simulate.sendTouchEvents(initialCoords, eventHolder, 'touchstart');
-            simulate.sendTouchEvents(finalCoords, eventHolder, 'touchmove');
-            simulate.sendTouchEvents(finalCoords, eventHolder, 'touchend');
-
-            expect(xaxis.min).toBeCloseTo((midPointCoords.x - initialXmin) * (1 - 1/amount) + initialXmin, 6);
-            expect(xaxis.max).toBeCloseTo(initialXmax - (initialXmax - midPointCoords.x) * (1 - 1/amount), 6);
-            expect(yaxis.min).toBeCloseTo((midPointCoords.y - initialYmin) * (1 - 1/amount) + initialYmin, 6);
-            expect(yaxis.max).toBeCloseTo(initialYmax - (initialYmax - midPointCoords.y) * (1 - 1/amount), 6);
-        });
-
-        it('for multiple touches should take into account just the first two of them and zoom',function() {
-            plot = $.plot(placeholder, [
-                [
-                    [-1, 2],
-                    [11, 12]
-                ]
-            ], options);
-
-            var eventHolder = plot.getEventHolder(),
-              xaxis = plot.getXAxes()[0],
-              yaxis = plot.getYAxes()[0],
-              initialXmin = xaxis.min,
-              initialXmax = xaxis.max,
-              initialYmin = yaxis.min,
-              initialYmax = yaxis.max,
-              initialCoords = [
-                  getPairOfCoords(xaxis, yaxis, 3, 5),
-                  getPairOfCoords(xaxis, yaxis, 7, 9),
-                  getPairOfCoords(xaxis, yaxis, 3, 7),
-                  getPairOfCoords(xaxis, yaxis, 5, 12)
-              ],
-              finalCoords = [
-                  getPairOfCoords(xaxis, yaxis, 2, 4),
-                  getPairOfCoords(xaxis, yaxis, 8, 10),
-                  getPairOfCoords(xaxis, yaxis, 3, 9),
-                  getPairOfCoords(xaxis, yaxis, 4, 20)
-              ],
-              midPointCoords = {
-                  x: (xaxis.c2p(finalCoords[0].x - plot.offset().left) + xaxis.c2p(finalCoords[1].x - plot.offset().left)) / 2,
-                  y: (yaxis.c2p(finalCoords[0].y - plot.offset().top) + yaxis.c2p(finalCoords[1].y - plot.offset().top)) / 2
-              },
-              amount = getDistance(finalCoords) / getDistance(initialCoords);
-
-            simulate.sendTouchEvents(initialCoords, eventHolder, 'touchstart');
-            simulate.sendTouchEvents(finalCoords, eventHolder, 'touchmove');
-            simulate.sendTouchEvents(finalCoords, eventHolder, 'touchend');
-
-            expect(xaxis.min).toBeCloseTo((midPointCoords.x - initialXmin) * (1 - 1/amount) + initialXmin, 6);
-            expect(xaxis.max).toBeCloseTo(initialXmax - (initialXmax - midPointCoords.x) * (1 - 1/amount), 6);
-            expect(yaxis.min).toBeCloseTo((midPointCoords.y - initialYmin) * (1 - 1/amount) + initialYmin, 6);
-            expect(yaxis.max).toBeCloseTo(initialYmax - (initialYmax - midPointCoords.y) * (1 - 1/amount), 6);
-        });
-
-        it('should ignore a third touch interference',function() {
-            plot = $.plot(placeholder, [
-                [
-                    [-1, 2],
-                    [11, 12]
-                ]
-            ], options);
-
-            var eventHolder = plot.getEventHolder(),
-              xaxis = plot.getXAxes()[0],
-              yaxis = plot.getYAxes()[0],
-              initialXmin = xaxis.min,
-              initialXmax = xaxis.max,
-              initialYmin = yaxis.min,
-              initialYmax = yaxis.max,
-              initialCoords = [
-                  getPairOfCoords(xaxis, yaxis, 3, 5),
-                  getPairOfCoords(xaxis, yaxis, 7, 9),
-              ],
-              intermediateCoords = [
-                  getPairOfCoords(xaxis, yaxis, 2, 4),
-                  getPairOfCoords(xaxis, yaxis, 8, 10),
-                  getPairOfCoords(xaxis, yaxis, 4, 20)
-              ],
-              finalCoords = [
-                  getPairOfCoords(xaxis, yaxis, 2, 4),
-                  getPairOfCoords(xaxis, yaxis, 8, 10),
-                  getPairOfCoords(xaxis, yaxis, 5, 17)
-              ],
-              midPointCoords = {
-                  x: (xaxis.c2p(finalCoords[0].x - plot.offset().left) + xaxis.c2p(finalCoords[1].x - plot.offset().left)) / 2,
-                  y: (yaxis.c2p(finalCoords[0].y - plot.offset().top) + yaxis.c2p(finalCoords[1].y - plot.offset().top)) / 2
-              },
-              amount = getDistance(finalCoords) / getDistance(initialCoords);
-
-            simulate.sendTouchEvents(initialCoords, eventHolder, 'touchstart');
-            simulate.sendTouchEvents(intermediateCoords, eventHolder, 'touchmove');
             simulate.sendTouchEvents(finalCoords, eventHolder, 'touchmove');
             simulate.sendTouchEvents(finalCoords, eventHolder, 'touchend');
 
@@ -442,8 +353,8 @@ describe("flot touch navigate plugin", function () {
               },
               xaxis: { autoscale: 'exact' },
               yaxis: { mode: 'log', showTickLabels: "all", autoscale: 'exact' },
-              zoom: { interactive: true, highlighted: true },
-              pan: { interactive: true, highlighted: true, enableTouch: true }
+              zoom: { interactive: true, active: true },
+              pan: { interactive: true, active: true, enableTouch: true }
           });
 
           var eventHolder = plot.getEventHolder(),
@@ -578,45 +489,6 @@ describe("flot touch navigate plugin", function () {
           expect(xaxis.max).toBeCloseTo(initialXmax, 6);
           expect(yaxis.min).toBeCloseTo(initialYmin, 6);
           expect(yaxis.max).toBeCloseTo(initialYmax, 6);
-      });
-
-      it('for multiple touches should take into account just the first two of them and pan',function() {
-          plot = $.plot(placeholder, [
-              [
-                  [-1, 2],
-                  [11, 12]
-              ]
-          ], options);
-
-          var eventHolder = plot.getEventHolder(),
-              xaxis = plot.getXAxes()[0],
-              yaxis = plot.getYAxes()[0],
-              initialXmin = xaxis.min,
-              initialXmax = xaxis.max,
-              initialYmin = yaxis.min,
-              initialYmax = yaxis.max,
-              canvasCoords = [ { x : 3, y : 5 }, { x : 7, y : 9 }, { x : 1, y : 30 },
-                 { x : 2, y : 4 }, { x : 6, y : 8 }, { x : 10, y : 11 }],
-              initialCoords = [
-                  getPairOfCoords(xaxis, yaxis, canvasCoords[0].x, canvasCoords[0].y),
-                  getPairOfCoords(xaxis, yaxis, canvasCoords[1].x, canvasCoords[1].y),
-                  getPairOfCoords(xaxis, yaxis, canvasCoords[2].x, canvasCoords[2].y)
-              ],
-              finalCoords = [
-                getPairOfCoords(xaxis, yaxis, canvasCoords[3].x, canvasCoords[3].y),
-                getPairOfCoords(xaxis, yaxis, canvasCoords[4].x, canvasCoords[4].y),
-                getPairOfCoords(xaxis, yaxis, canvasCoords[5].x, canvasCoords[5].y)
-              ];
-
-          simulate.sendTouchEvents(initialCoords, eventHolder, 'touchstart');
-          simulate.sendTouchEvents(finalCoords, eventHolder, 'touchmove');
-          simulate.sendTouchEvents(finalCoords, eventHolder, 'touchend');
-
-          expect(xaxis.min).toBeCloseTo(initialXmin + (canvasCoords[0].x - canvasCoords[3].x), 6);
-          expect(xaxis.max).toBeCloseTo(initialXmax + (canvasCoords[0].x - canvasCoords[3].x), 6);
-          expect(yaxis.min).toBeCloseTo(initialYmin + (canvasCoords[0].y - canvasCoords[3].y), 6);
-          expect(yaxis.max).toBeCloseTo(initialYmax + (canvasCoords[0].y - canvasCoords[3].y), 6);
-
       });
 
       it('should drag the plot on the yaxis only', function() {


### PR DESCRIPTION
* activate plot touch navigation only after tap on plot
* get out of extreme zoom with three fingers pinch by allowing the event propagation to browser
* tests for double tap, zoom and pan 