### PR TITLE
Activating dont-break on CircleCI

### DIFF
--- a/.dont-break.json
+++ b/.dont-break.json
@@ -1,0 +1,5 @@
+[
+  "https://github.com/ni-kismet/flot-cursors-plugin",
+  "https://github.com/ni-kismet/flot-intensitygraph-plugin",
+  "https://github.com/ni-kismet/flot-charting"
+]

--- a/.dont-break.json
+++ b/.dont-break.json
@@ -2,7 +2,5 @@
     "https://github.com/ni-kismet/flot-cursors-plugin",
     "https://github.com/ni-kismet/flot-intensitygraph-plugin",
     "https://github.com/ni-kismet/flot-charting",
-    "https://github.com/ni-kismet/webcharts",
-    "https://github.com/ni-kismet/webcharts-legends",
-    "https://github.com/ni-kismet/HeliumUI"
+    "https://github.com/ni-kismet/webcharts"
 ]

--- a/.dont-break.json
+++ b/.dont-break.json
@@ -1,5 +1,6 @@
 [
-  "https://github.com/ni-kismet/flot-cursors-plugin",
-  "https://github.com/ni-kismet/flot-intensitygraph-plugin",
-  "https://github.com/ni-kismet/flot-charting"
+    "https://github.com/ni-kismet/webcharts",
+    "https://github.com/ni-kismet/flot-cursors-plugin",
+    "https://github.com/ni-kismet/flot-intensitygraph-plugin",
+    "https://github.com/ni-kismet/flot-charting"
 ]

--- a/.dont-break.json
+++ b/.dont-break.json
@@ -1,6 +1,8 @@
 [
-    "https://github.com/ni-kismet/webcharts",
     "https://github.com/ni-kismet/flot-cursors-plugin",
     "https://github.com/ni-kismet/flot-intensitygraph-plugin",
-    "https://github.com/ni-kismet/flot-charting"
+    "https://github.com/ni-kismet/flot-charting",
+    "https://github.com/ni-kismet/webcharts",
+    "https://github.com/ni-kismet/webcharts-legends",
+    "https://github.com/ni-kismet/HeliumUI"
 ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# engineering-flot [![Build Status](https://travis-ci.org/ni-kismet/engineering-flot.svg?branch=master)](https://travis-ci.org/ni-kismet/engineering-flot) [![CircleCI](https://circleci.com/gh/ni-kismet/engineering-flot.svg?style=svg)](https://circleci.com/gh/ni-kismet/engineering-flot) [![Coverage Status](https://coveralls.io/repos/github/ni-kismet/engineering-flot/badge.svg?branch=master)](https://coveralls.io/github/ni-kismet/engineering-flot?branch=master)
-
-[![Greenkeeper badge](https://badges.greenkeeper.io/ni-kismet/engineering-flot.svg)](https://greenkeeper.io/)
+# engineering-flot [![Build Status](https://travis-ci.org/ni-kismet/engineering-flot.svg?branch=master)](https://travis-ci.org/ni-kismet/engineering-flot) [![CircleCI](https://circleci.com/gh/ni-kismet/engineering-flot.svg?style=svg)](https://circleci.com/gh/ni-kismet/engineering-flot) [![Coverage Status](https://coveralls.io/repos/github/ni-kismet/engineering-flot/badge.svg?branch=master)](https://coveralls.io/github/ni-kismet/engineering-flot?branch=master) [![Greenkeeper badge](https://badges.greenkeeper.io/ni-kismet/engineering-flot.svg)](https://greenkeeper.io/)
 
 ## About ##
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# engineering-flot [![Build Status](https://travis-ci.org/ni-kismet/engineering-flot.svg?branch=master)](https://travis-ci.org/ni-kismet/engineering-flot) [![Coverage Status](https://coveralls.io/repos/github/ni-kismet/engineering-flot/badge.svg?branch=master)](https://coveralls.io/github/ni-kismet/engineering-flot?branch=master)
+# engineering-flot [![Build Status](https://travis-ci.org/ni-kismet/engineering-flot.svg?branch=master)](https://travis-ci.org/ni-kismet/engineering-flot) [![CircleCI](https://circleci.com/gh/ni-kismet/engineering-flot.svg?style=svg)](https://circleci.com/gh/ni-kismet/engineering-flot) [![Coverage Status](https://coveralls.io/repos/github/ni-kismet/engineering-flot/badge.svg?branch=master)](https://coveralls.io/github/ni-kismet/engineering-flot?branch=master)
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/ni-kismet/engineering-flot.svg)](https://greenkeeper.io/)
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,9 @@ dependencies:
     - node --version
     - npm --version
   post:
+    - printenv
+    - env
+    - echo $NPM_TOKEN
     - npm install -g dont-break
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -13,10 +13,8 @@ dependencies:
     - curl -s https://raw.githubusercontent.com/chronogolf/circleci-google-chrome/master/use_chrome_stable_version.sh | bash
     - node --version
     - npm --version
+    - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
   post:
-    - printenv
-    - env
-    - echo $NPM_TOKEN
     - npm install -g dont-break
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -3,9 +3,6 @@ machine:
     version: "8.2.0"
 dependencies:
   pre:
-    #- mkdir ../ff-release
-    #- wget -O ff-release.tar.bz2 'https://archive.mozilla.org/pub/firefox/releases/43.0b5/linux-x86_64/en-US/firefox-43.0b5.tar.bz2' && tar xjf ff-release.tar.bz2:
-    #    pwd: ../ff-release
     - sudo apt-get update
     - sudo apt-get install libpango1.0-0
     - sudo apt-get install firefox

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,20 @@
+machine:
+  node:
+    version: "8.2.0"
+dependencies:
+  pre:
+    #- mkdir ../ff-release
+    #- wget -O ff-release.tar.bz2 'https://archive.mozilla.org/pub/firefox/releases/43.0b5/linux-x86_64/en-US/firefox-43.0b5.tar.bz2' && tar xjf ff-release.tar.bz2:
+    #    pwd: ../ff-release
+    - sudo apt-get update
+    - sudo apt-get install libpango1.0-0
+    - sudo apt-get install firefox
+    - sudo ln -sf /usr/lib/firefox/firefox /usr/bin/firefox
+    - curl -s https://raw.githubusercontent.com/chronogolf/circleci-google-chrome/master/use_chrome_stable_version.sh | bash
+    - node --version
+    - npm --version
+  post:
+    - npm install -g dont-break
+test:
+  override:
+    - npm run dont-break

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "test": "node node_modules/karma/bin/karma start --single-run --no-auto-watch --concurrency=1 && npm run build-test",
     "coverage": "node node_modules/karma/bin/karma start --single-run --coverage --no-auto-watch --concurrency=1",
     "build": "node build",
-    "build-test": "npm --silent run build test"
+    "build-test": "npm --silent run build test",
+    "dont-break": "dont-break --timeout 300"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
dont-break can be used to check whether the next version of a package will break the dependents.

Because the free plan from CircleCI is limited to 1500 build hours/month, at this point CircleCI/engineering-flot was configured to start a build for PRs only. Eventually we could remove this limitation and let any push to any branch to start a new build.

CircleCI is configured to run in parallel with Travis, but only the Travis build are required to pass in order to merge a PR.