### PR TITLE
Patching dont-break

### DIFF
--- a/.dont-break.json
+++ b/.dont-break.json
@@ -1,8 +1,8 @@
 [
-    "https://github.com/ni-kismet/HeliumUI",
     "https://github.com/ni-kismet/flot-cursors-plugin",
     "https://github.com/ni-kismet/flot-intensitygraph-plugin",
     "https://github.com/ni-kismet/flot-charting",
     "https://github.com/ni-kismet/webcharts",
-    "https://github.com/ni-kismet/webcharts-legends"
+    "https://github.com/ni-kismet/webcharts-legends",
+    "https://github.com/ni-kismet/HeliumUI"
 ]

--- a/.dont-break.json
+++ b/.dont-break.json
@@ -1,4 +1,5 @@
 [
+    "https://github.com/ni-kismet/webcharts-legends",
     "https://github.com/ni-kismet/flot-cursors-plugin",
     "https://github.com/ni-kismet/flot-intensitygraph-plugin",
     "https://github.com/ni-kismet/flot-charting",

--- a/.dont-break.json
+++ b/.dont-break.json
@@ -1,7 +1,8 @@
 [
-    "https://github.com/ni-kismet/webcharts-legends",
+    "https://github.com/ni-kismet/HeliumUI",
     "https://github.com/ni-kismet/flot-cursors-plugin",
     "https://github.com/ni-kismet/flot-intensitygraph-plugin",
     "https://github.com/ni-kismet/flot-charting",
-    "https://github.com/ni-kismet/webcharts"
+    "https://github.com/ni-kismet/webcharts",
+    "https://github.com/ni-kismet/webcharts-legends"
 ]

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
   post:
     # testing indirect dependents is not supported yet by the mainline version
     # https://github.com/bahmutov/dont-break/pull/57
-    - npm install -g npm git+https://cristiingineru@github.com/cristiingineru/dont-break.git
+    - npm install -g git+https://cristiingineru@github.com/cristiingineru/dont-break.git
 test:
   override:
     - npm run dont-break

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
   post:
     # testing indirect dependents is not supported yet by the mainline version
     # https://github.com/bahmutov/dont-break/pull/57
-    - npm install -g git+https://cristiingineru@github.com/cristiingineru/dont-break.git
+    - npm install -g git+https://cristiingineru@github.com/cristiingineru/dont-break.git#allowTestingIndirectDependents
 test:
   override:
     - npm run dont-break

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,9 @@ dependencies:
     - npm --version
     - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
   post:
-    - npm install -g dont-break
+    # testing indirect dependents is not supported yet by the mainline version
+    # https://github.com/bahmutov/dont-break/pull/57
+    - npm install -g npm git+https://cristiingineru@github.com/cristiingineru/dont-break.git
 test:
   override:
     - npm run dont-break


### PR DESCRIPTION
The mainline/released version of dont-break doesn't allow testing indirect dependents.

This change is installing a custom version of dont-break and adds a few indirect dependents to the dont-break list.