### PR TITLE
Example gl plotter

### DIFF
--- a/examples/distribution/index.html
+++ b/examples/distribution/index.html
@@ -2,44 +2,28 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>Flot Examples: Basic Usage</title>
+    <title>Flot Examples: GlPlotter </title>
     <link href="../examples.css" rel="stylesheet" type="text/css">
     <script language="javascript" type="text/javascript" src="../../jquery.js"></script>
     <script language="javascript" type="text/javascript" src="../../node_modules/three/build/three.min.js"></script>
     <script language="javascript" type="text/javascript" src="../../dist/jquery.flot.js"></script>
+    <script language="javascript" type="text/javascript" src="../../jquery.flot.symbol.js"></script>
     <script language="javascript" type="text/javascript" src="../../jquery.flot.glplotter.js"></script>
     <script type="text/javascript">
 
     $(function() {
 
         var plot, cx = 0, cy = 0, r = 10, n = 10000, data, options = {
-                    lines: {
-                        show: true
-                    },
-                    points: {
-                        show: true
-                    }
-                ,
-                xaxis: {
-                    show: true,
-                    autoscale: false,
-                    min: -10,
-                    max: 10
-                },
-                yaxis: {
-                    show: true,
-                    autoscale: false,
-                    min: -10,
-                    max: 10
-                }
+                xaxis: { show: true, autoscale: false, min: -10, max: 10 },
+                yaxis: { show: true, autoscale: false, min: -10, max: 10 }
             };
 
         function initData() {
             data = [
                 {
                     data: [],
-                    points: { show: true },
-                    lines: { show: false}
+                    points: { show: true, symbol: 'cross', glshow: false },
+                    lines: { show: false }
                 }
             ];
             for (var i = 0; i < n; i++) {
@@ -89,6 +73,8 @@
     </div>
 
     <div id="content">
+        <br/>
+        <p>In order to activate the GlPlotter plugin you have to append <strong>?gl=true</strong> to the address.</p>
 
         <div class="demo-container">
             <div id="placeholder" class="demo-placeholder"></div>
@@ -102,6 +88,8 @@
             <input type="radio" name="scaling" value="20000" /> 20k <br />
             <input type="radio" name="scaling" value="25000" /> 25k <br />
             <input type="radio" name="scaling" value="50000" /> 50k <br />
+            <input type="radio" name="scaling" value="75000" /> 75k <br />
+            <input type="radio" name="scaling" value="100000" /> 100k <br />
         </fieldset>
 
     </div>

--- a/examples/distribution/index.html
+++ b/examples/distribution/index.html
@@ -12,7 +12,7 @@
 
     $(function() {
 
-        var plot = $.plot("#placeholder", [[]], {
+        var plot, cx = 0, cy = 0, r = 10, n = 10000, data, options = {
                     lines: {
                         show: true
                     },
@@ -22,37 +22,58 @@
                 ,
                 xaxis: {
                     show: true,
+                    autoscale: false,
                     min: -10,
                     max: 10
                 },
                 yaxis: {
                     show: true,
+                    autoscale: false,
                     min: -10,
                     max: 10
                 }
-            });
+            };
 
-        var cx = 0, cy = 0, r = 10, n = 1000, data = [
+        function initData() {
+            data = [
                 {
                     data: [],
                     points: { show: true },
-                    lines: { show: true}
+                    lines: { show: false}
                 }
             ];
+            for (var i = 0; i < n; i++) {
+                data[0].data[i] = [];
+            }
+        }
 
         function update() {
-            var serie = data[0].data, point = [];
+            if (!data || data[0].data.length !== n) {
+                initData();
+            }
+
+            var serie = data[0].data;
             for (var i = 0; i < n; i++) {
+                point = serie[i];
                 point[0] = cx + r * Math.random() * (Math.random() < 0.5 ? -1 : 1);
                 point[1] = cy + r * Math.random() * (Math.random() < 0.5 ? -1 : 1);
-                serie[i] = point;
             }
 
             plot.setData(data);
+            plot.setupGrid();
+            plot.draw();
             window.requestAnimationFrame(update);
         }
 
+        plot = $.plot("#placeholder", [], options);
         window.requestAnimationFrame(update);
+
+        $('#scaling input').on('change', function() {
+            var val = $('input[name="scaling"]:checked', '#scaling').val();
+
+            n = parseInt(val);
+            plot = $.plot("#placeholder", [], options);
+        });
 
         // Add the Flot version string to the footer
 
@@ -73,9 +94,15 @@
             <div id="placeholder" class="demo-placeholder"></div>
         </div>
 
-        <p>You don't have to do much to get an attractive plot.  Create a placeholder, make sure it has dimensions (so Flot knows at what size to draw the plot), then call the plot function with your data.</p>
-
-        <p>The axes are automatically scaled.</p>
+        <br>
+        <fieldset id="scaling">
+            <legend>Point count</legend>
+            <input type="radio" name="scaling" value="10000" checked="checked" /> 10k <br />
+            <input type="radio" name="scaling" value="15000"/> 15k <br />
+            <input type="radio" name="scaling" value="20000" /> 20k <br />
+            <input type="radio" name="scaling" value="25000" /> 25k <br />
+            <input type="radio" name="scaling" value="50000" /> 50k <br />
+        </fieldset>
 
     </div>
 

--- a/examples/distribution/index.html
+++ b/examples/distribution/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Flot Examples: Basic Usage</title>
+    <link href="../examples.css" rel="stylesheet" type="text/css">
+    <script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+    <script language="javascript" type="text/javascript" src="../../node_modules/three/build/three.min.js"></script>
+    <script language="javascript" type="text/javascript" src="../../dist/jquery.flot.js"></script>
+    <script language="javascript" type="text/javascript" src="../../jquery.flot.glplotter.js"></script>
+    <script type="text/javascript">
+
+    $(function() {
+
+        var plot = $.plot("#placeholder", [[]], {
+                    lines: {
+                        show: true
+                    },
+                    points: {
+                        show: true
+                    }
+                ,
+                xaxis: {
+                    show: true,
+                    min: -10,
+                    max: 10
+                },
+                yaxis: {
+                    show: true,
+                    min: -10,
+                    max: 10
+                }
+            });
+
+        var cx = 0, cy = 0, r = 10, n = 1000, data = [
+                {
+                    data: [],
+                    points: { show: true },
+                    lines: { show: true}
+                }
+            ];
+
+        function update() {
+            var serie = data[0].data, point = [];
+            for (var i = 0; i < n; i++) {
+                point[0] = cx + r * Math.random() * (Math.random() < 0.5 ? -1 : 1);
+                point[1] = cy + r * Math.random() * (Math.random() < 0.5 ? -1 : 1);
+                serie[i] = point;
+            }
+
+            plot.setData(data);
+            window.requestAnimationFrame(update);
+        }
+
+        window.requestAnimationFrame(update);
+
+        // Add the Flot version string to the footer
+
+        $("#footer").prepend("Flot " + $.plot.version + " &ndash; ");
+    });
+
+    </script>
+</head>
+<body>
+
+    <div id="header">
+        <h2>Basic Usage</h2>
+    </div>
+
+    <div id="content">
+
+        <div class="demo-container">
+            <div id="placeholder" class="demo-placeholder"></div>
+        </div>
+
+        <p>You don't have to do much to get an attractive plot.  Create a placeholder, make sure it has dimensions (so Flot knows at what size to draw the plot), then call the plot function with your data.</p>
+
+        <p>The axes are automatically scaled.</p>
+
+    </div>
+
+    <div id="footer">
+        Copyright &copy; 2007 - 2014 IOLA and Ole Laursen
+    </div>
+
+</body>
+</html>

--- a/jquery.flot.glplotter.js
+++ b/jquery.flot.glplotter.js
@@ -19,9 +19,7 @@ function GlPlotter() {
         var container, canvas, width, height,
             renderer, pixelRatio;
 
-        if (isGlRequested()) {
-            plot.hooks.processOptions.push(processOptions);
-        }
+        plot.hooks.processOptions.push(processOptions);
 
         function isGlRequested() {
             var url = window.location.href,

--- a/jquery.flot.glplotter.js
+++ b/jquery.flot.glplotter.js
@@ -18,7 +18,19 @@ function GlPlotter() {
             geometries = [];
         var container, canvas, width, height,
             renderer, pixelRatio;
-        plot.hooks.processOptions.push(processOptions);
+
+        if (isGlRequested()) {
+            plot.hooks.processOptions.push(processOptions);
+        }
+
+        function isGlRequested() {
+            var url = window.location.href,
+                params = url.split('?')[1],
+                searchParams = new URLSearchParams(params);
+            if (searchParams.get('gl') === 'true') {
+                return true;
+            }
+        }
 
         function processOptions(plot, options) {
             var mainScene, camera, cameraFocus;
@@ -27,7 +39,7 @@ function GlPlotter() {
             if(!canvas) {
                 canvas = getGlSurface("flot-gl", container);
             }
-    
+
             if(!renderer) {
                 renderer = new THREE.WebGLRenderer({ canvas: canvas, antialias: false, alpha: true });
                 mainScene = new THREE.Scene();
@@ -41,7 +53,7 @@ function GlPlotter() {
                         renderer.msBackingStorePixelRatio ||
                         renderer.oBackingStorePixelRatio ||
                         renderer.backingStorePixelRatio || 1;
-    
+
                 pixelRatio = devicePixelRatio / backingStoreRatio;
             } else {
                 mainScene = renderer.userData.mainScene;
@@ -69,7 +81,7 @@ function GlPlotter() {
             renderer.userData.plotOffset = defaultPlotOffset;
 
             resize(plot, width, height);
-            
+
             plot.hooks.drawSeries.push(drawSeries);
             plot.hooks.draw.push(render);
             plot.hooks.resize.push(resize);
@@ -100,7 +112,7 @@ function GlPlotter() {
             // but its screen is actually 640px wide.  It therefore has a pixel
             // ratio of 2, while most normal devices have a ratio of 1.
 
-            
+
             var box = container.getBoundingClientRect();
 
             // Size the canvas to match the internal dimensions of its container
@@ -143,45 +155,45 @@ function GlPlotter() {
                 minSize = 10,
                 shouldresize = false,
                 element = canvas;
-    
+
                 newWidth = newWidth < minSize ? minSize : newWidth;
                 newHeight = newHeight < minSize ? minSize : newHeight;
-    
+
                 // Resize the canvas, increasing its density based on the display's
                 // pixel ratio; basically giving it more pixels without increasing the
                 // size of its element, to take advantage of the fact that retina
                 // displays have that many more pixels in the same advertised space.
-        
+
                 // Resizing should reset the state (excanvas seems to be buggy though)
-        
+
                 if (width !== newWidth) {
                     element.width = newWidth * pixelRatio;
                     element.style.width = newWidth + 'px';
                     width = newWidth;
-                    shouldresize = true; 
+                    shouldresize = true;
                 }
-        
+
                 if (height !== newHeight) {
                     element.height = newHeight * pixelRatio;
                     element.style.height = newHeight + 'px';
                     height = newHeight;
                     shouldresize = true;
                 }
-    
+
                 if (renderer && shouldresize) {
                     var mainscene = renderer.userData.mainScene,
                         camera = renderer.userData.camera;
-    
+
                     renderer.setClearColor(0xff0000, 0);
                     renderer.setSize(width, height, false);
                     renderer.setPixelRatio(pixelRatio);
-    
+
                     if(camera) {
                         camera.aspect = width/height;
                         camera.userData.cameraFocus.x = width / 2;
                         camera.userData.cameraFocus.y = height / 2;
                         camera.userData.cameraFocus.z = 1000;
-        
+
                         camera.position.set(width / 2, height / 2, 0);
                         camera.lookAt(camera.userData.cameraFocus);
                         camera.updateMatrixWorld();
@@ -199,11 +211,11 @@ function GlPlotter() {
                 renderer.setClearColor(0x0f0f0f, 0);
                 renderer.setScissorTest(false);
                 renderer.clear();
-    
+
                 while (mainscene.children.length > 0) {
                     mainscene.remove(mainscene.children[0]);
                 }
-    
+
                 renderer.setClearColor(0xff0000, 0);
                 renderer.setScissorTest(true);
                 renderer.clear();
@@ -218,7 +230,7 @@ function GlPlotter() {
         function drawSeries(plot, ctx, serie, index, getColorOrGradient) {
             var plotOffset = plot.getPlotOffset(),
                 plotWidth, plotHeight;
-            if(serie.points.glshow || serie.points.show) {
+            if (serie.points.glshow || (serie.points.show && isGlRequested())) {
                 serie.points.show = false;
                 serie.points.glshow = true;
                 renderer.userData.plotOffset = plotOffset;
@@ -251,19 +263,19 @@ function GlPlotter() {
                     points: serie.datapoints.points,
                     pointsize: serie.datapoints.pointsize
                 };
-    
+
                 if (serie.decimatePoints) {
                     //after adjusting the axis, plot width and height will be modified
                     plotWidth = width - plotOffset.left - plotOffset.right;
                     plotHeight = height - plotOffset.bottom - plotOffset.top;
                     // TODO: return Vector3 array of p2c coords after switching to BufferGeometry.
                     datapoints.points = serie.decimatePoints(
-                        serie, 
-                        serie.xaxis.min, 
-                        serie.xaxis.max, 
-                        plotWidth, 
-                        serie.yaxis.min, 
-                        serie.yaxis.max, 
+                        serie,
+                        serie.xaxis.min,
+                        serie.xaxis.max,
+                        plotWidth,
+                        serie.yaxis.min,
+                        serie.yaxis.max,
                         plotHeight
                     );
                 }
@@ -323,17 +335,17 @@ function GlPlotter() {
                 material = materials[index],
                 vertices = geometry.vertices,
                 points = datapoints.points,
-                ps = datapoints.pointsize, 
+                ps = datapoints.pointsize,
                 x, y, z = 1000 - index;
             var i = 0, j = 0, k = 0;
-        
+
             // move/create each vertex
             for (i = 0; i < points.length; i += ps) {
                 if (points[i] == null) {
                     j++;
                     continue;
                 }
-                
+
                 if (points[i] < axisx.min || points[i] > axisx.max || points[i + 1] < axisy.min || points[i + 1] > axisy.max) {
                     if (vertices[i / ps - j]) {
                         vertices[i / ps - j].z = -1;
@@ -352,7 +364,7 @@ function GlPlotter() {
                     vertices[i / ps - j].z = z;
                 }
             }
-            
+
             if (vertices.length > points.length / ps) {
                 for(k = points.length / ps; k < vertices.length; k++) {
                     vertices[k].z = -1;


### PR DESCRIPTION
1. Adding a very basic example for scatter data
2. Adding a switch to force the glplotter plugin when the address of the page contain the gl=true parameter

Now the plugin can be activated in 2 ways:
1. using the gl=true argument in the address, example: http://localhost:2000/examples/distribution/?gl=false This will override the default drawing function for all the point series.
2. passing glshow=true to the data option, example:
```js
var data = [
                {
                    data: [[x1, y1], [x2, y2], [x3, y3]],
                    points: { show: true, symbol: 'cross', glshow: false },
                    lines: { show: false }
                }
            ];
plot.setData(data);
plot.setupGrid();
plot.draw();
```