### PR TITLE
Axis tick label margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0.3]
+### Changes ###
+
+- Change jquery.flot.legend.js to use SVG and add it to the distribution
+
+### Bug fixes ###
+
+- No minimum margin for axis tick labels
+
+
 ## [1.0.2]
 ### Changes ###
 
 - Expose the composeImages as part of the plot instance
 
 ### Bug fixes ###
+
 - The speed of the zoom made on the Mac track pad
 - Invalid SVG width and height values red by composeImages on Firefox
 
@@ -15,7 +26,6 @@ All notable changes to this project will be documented in this file.
 ### Changes ###
 
 - Added jquery.flot.composeImages.js to distribution
-- Change jquery.flot.legend.js to use SVG and add it to the distribution
 
 
 ## [1.0.0]
@@ -1397,6 +1407,7 @@ Moved labelMargin option to grid from x/yaxis.
 First public release.
 
 
+[1.0.3]: https://github.com/ni-kismet/engineering-flot/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/ni-kismet/engineering-flot/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/ni-kismet/engineering-flot/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/ni-kismet/engineering-flot/compare/v0.6.0...v1.0.0

--- a/dist/es5/jquery.flot.js
+++ b/dist/es5/jquery.flot.js
@@ -2966,6 +2966,7 @@ Licensed under the MIT license.
                     layer = "flot-" + axis.direction + "-axis flot-" + axis.direction + axis.n + "-axis " + legacyStyles,
                     font = axis.options.font || "flot-tick-label tickLabel",
                     i, x, y, halign, valign, info,
+                    margin = 3,
                     nullBox = {x: NaN, y: NaN, width: NaN, height: NaN}, newLabelBox, labelBoxes = [],
                     overlapping = function(x11, y11, x12, y12, x21, y21, x22, y22) {
                         return ((x11 <= x21 && x21 <= x12) || (x21 <= x11 && x11 <= x22)) &&
@@ -2994,7 +2995,7 @@ Licensed under the MIT license.
                                 y = box.top + box.height - box.padding + axis.boxPosition.centerY;
                                 valign = "bottom";
                             }
-                            newLabelBox = {x: x - info.width / 2, y: y, width: info.width, height: info.height}
+                            newLabelBox = {x: x - info.width / 2 - margin, y: y - margin, width: info.width + 2 * margin, height: info.height + 2 * margin};
                         } else {
                             valign = "middle";
                             y = plotOffset.top + axis.p2c(tick.v);
@@ -3004,7 +3005,7 @@ Licensed under the MIT license.
                             } else {
                                 x = box.left + box.padding + axis.boxPosition.centerX;
                             }
-                            newLabelBox = {x: x, y: y - info.height / 2, width: info.width, height: info.height}
+                            newLabelBox = {x: x - info.width / 2 - margin, y: y - margin, width: info.width + 2 * margin, height: info.height + 2 * margin};
                         }
 
                         if (overlapsOtherLabels(newLabelBox, labelBoxes)) {

--- a/jquery.flot.js
+++ b/jquery.flot.js
@@ -2257,6 +2257,7 @@ Licensed under the MIT license.
                     layer = "flot-" + axis.direction + "-axis flot-" + axis.direction + axis.n + "-axis " + legacyStyles,
                     font = axis.options.font || "flot-tick-label tickLabel",
                     i, x, y, halign, valign, info,
+                    margin = 3,
                     nullBox = {x: NaN, y: NaN, width: NaN, height: NaN}, newLabelBox, labelBoxes = [],
                     overlapping = function(x11, y11, x12, y12, x21, y21, x22, y22) {
                         return ((x11 <= x21 && x21 <= x12) || (x21 <= x11 && x11 <= x22)) &&
@@ -2285,7 +2286,7 @@ Licensed under the MIT license.
                                 y = box.top + box.height - box.padding + axis.boxPosition.centerY;
                                 valign = "bottom";
                             }
-                            newLabelBox = {x: x - info.width / 2, y: y, width: info.width, height: info.height}
+                            newLabelBox = {x: x - info.width / 2 - margin, y: y - margin, width: info.width + 2 * margin, height: info.height + 2 * margin};
                         } else {
                             valign = "middle";
                             y = plotOffset.top + axis.p2c(tick.v);
@@ -2295,7 +2296,7 @@ Licensed under the MIT license.
                             } else {
                                 x = box.left + box.padding + axis.boxPosition.centerX;
                             }
-                            newLabelBox = {x: x, y: y - info.height / 2, width: info.width, height: info.height}
+                            newLabelBox = {x: x - info.width / 2 - margin, y: y - margin, width: info.width + 2 * margin, height: info.height + 2 * margin};
                         }
 
                         if (overlapsOtherLabels(newLabelBox, labelBoxes)) {

--- a/tests/jquery.flot.logaxis.Test.js
+++ b/tests/jquery.flot.logaxis.Test.js
@@ -4,7 +4,7 @@
 describe("unit tests for the log scale functions", function() {
     var placeholder;
     beforeEach(function() {
-        placeholder = setFixtures('<div id="test-container" style="width: 600px;height: 400px">')
+        placeholder = setFixtures('<div id="test-container" style="width: 800px;height: 400px">')
             .find('#test-container');
     });
 


### PR DESCRIPTION
1. With HTML based labels it was possible to specify in CSS a margin to make sure there is a minimum distance between 2 labels. With SVG this is not possible anymore, so this change is introducing a small fixed margin of 2 * 3 px between 2 consecutive axis tick labels.
2. Fixing the CHANGELOG.md file.