### PR TITLE
Activate graph navigation on double click

### DIFF
--- a/dist/es5/jquery.flot.js
+++ b/dist/es5/jquery.flot.js
@@ -4934,6 +4934,11 @@ can set the default in the options.
         }
 
         function onDblClick(e) {
+            var o = plot.getOptions();
+            if (!o.pan.active || !o.zoom.active) {
+                o.pan.active = true;
+                o.zoom.active = true;
+            }
             plot.getPlaceholder().trigger("re-center", e);
         }
 

--- a/jquery.flot.navigate.js
+++ b/jquery.flot.navigate.js
@@ -262,6 +262,11 @@ can set the default in the options.
         }
 
         function onDblClick(e) {
+            var o = plot.getOptions();
+            if (!o.pan.active || !o.zoom.active) {
+                o.pan.active = true;
+                o.zoom.active = true;
+            }
             plot.getPlaceholder().trigger("re-center", e);
         }
 

--- a/tests/jquery.flot.navigate.Test.js
+++ b/tests/jquery.flot.navigate.Test.js
@@ -773,4 +773,26 @@ describe("flot navigate plugin", function () {
               expect(plot.getOptions().zoom.active).toBe(true);
         });
     });
+
+    describe('mouse dblclick', function(){
+        it('on plot activates plot\'s zoom and pan active propriety', function() {
+            plot = $.plot(placeholder, [
+                [
+                    [0, 0],
+                    [10, 10]
+                ]
+              ], {
+                  zoom: { interactive: true, active: false, amount: 10 },
+                  pan: { interactive: true, active: false}
+              });
+
+              var eventHolder = plot.getEventHolder(),
+                  pointCoords = { x: 0, y: plot.height() };
+
+              simulate.dblclick(eventHolder, pointCoords.x, pointCoords.y);
+
+              expect(plot.getOptions().pan.active).toBe(true);
+              expect(plot.getOptions().zoom.active).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
The graph navigation was activated only on mouse click. This means that if the user performed a dblclick operation, the graph will autoscale, but the navigation was still not active.
See [issue 174](https://github.com/ni-kismet/engineering-flot/issues/174) 