### PR TITLE
Removed global options object in flot.legend

### DIFF
--- a/jquery.flot.legend.js
+++ b/jquery.flot.legend.js
@@ -3,9 +3,7 @@
 */
 
 (function($) {
-    var placeholder;
-
-    var options = {
+    var defaultOptions = {
         legend: {
             show: false,
             labelFormatter: null, // fn: string -> string
@@ -16,7 +14,7 @@
         }
     };
 
-    function insertLegend(plot, legendEntries) {
+    function insertLegend(plot, options, placeholder, legendEntries) {
         // clear before redraw
         if (options.legend.container != null) {
             $(options.legend.container).html('');
@@ -372,10 +370,8 @@
     }
 
     function init(plot) {
-        placeholder = plot.getPlaceholder();
-        options = plot.getOptions();
-
         plot.hooks.setupGrid.push(function (plot) {
+            var options = plot.getOptions();
             var series = plot.getData(),
                 labelFormatter = options.legend.labelFormatter,
                 oldEntries = options.legend.legendEntries,
@@ -385,14 +381,14 @@
 
             if (shouldRedraw(oldEntries, newEntries) ||
                 checkOptions(oldPlotOffset, newPlotOffset)) {
-                insertLegend(plot, newEntries);
+                insertLegend(plot, options, plot.getPlaceholder(), newEntries);
             }
         });
     }
 
     $.plot.plugins.push({
         init: init,
-        options: options,
+        options: defaultOptions,
         name: 'legend',
         version: '1.0'
     });


### PR DESCRIPTION
This fixes an issue when using multiple plots with legends. Before this change, the global options object would refer to the options of the last plot that called init. Because of this, when multiple plots would execute the setupGrid hook, it could insert the legend elements into the wrong container.