### PR TITLE
Time formatting fix for edge

### DIFF
--- a/source/jquery.flot.absRelTime.js
+++ b/source/jquery.flot.absRelTime.js
@@ -285,6 +285,13 @@ the the second one the date in gregorian date format.
             return timeString + (dateString !== "" && timeString !== "" ? "<br>" : "") + dateString;
         }
 
+        function getDefaultDateTimeString(gregorianDate, showMilliseconds, ms) {
+            var msString = showMilliseconds ? '.' + padNTimes(ms, '0', 3) : '';
+            time = Globalize.format(gregorianDate, "T", formatLanguage());
+            time = addMilliseconds(time, msString) + '<br>' + Globalize.format(gregorianDate, "d", formatLanguage());
+            return time;
+        }
+
         function toAbsoluteTimeStr(date, showMilliseconds, formatString, timeEpoch) {
             var unixToAbsoluteEpochDiff = 62135596800000,
                 minDateValue = -8640000000000000,
@@ -303,11 +310,14 @@ the the second one the date in gregorian date format.
 
             var time;
             if (formatString !== "") {
-                time = getFormattedDateTimeString(gregorianDate, formatString);
+                try {
+                    time = getFormattedDateTimeString(gregorianDate, formatString);
+                }
+                catch(err) {
+                    time = getDefaultDateTimeString(gregorianDate, showMilliseconds, ms);
+                }
             } else {
-                var msString = showMilliseconds ? '.' + padNTimes(ms, '0', 3) : '';
-                time = Globalize.format(gregorianDate, "T", formatLanguage());
-                time = addMilliseconds(time, msString) + '<br>' + Globalize.format(gregorianDate, "d", formatLanguage());
+                time = getDefaultDateTimeString(gregorianDate, showMilliseconds, ms);
             }
 
             return time;

--- a/source/jquery.flot.absRelTime.js
+++ b/source/jquery.flot.absRelTime.js
@@ -287,7 +287,7 @@ the the second one the date in gregorian date format.
 
         function getDefaultDateTimeString(gregorianDate, showMilliseconds, ms) {
             var msString = showMilliseconds ? '.' + padNTimes(ms, '0', 3) : '';
-            time = Globalize.format(gregorianDate, "T", formatLanguage());
+            var time = Globalize.format(gregorianDate, "T", formatLanguage());
             time = addMilliseconds(time, msString) + '<br>' + Globalize.format(gregorianDate, "d", formatLanguage());
             return time;
         }


### PR DESCRIPTION
A recent-ish change, by me, introduced the usage of 'formatToParts' to enable a wider axis formatting set of options. This, however, is not supported on Edge, so Edge has been broken for some time (and there are currently tests that will fail on Edge).

A future update will include updates to the tests that allow us to mark certain tests so that they don't run on Edge, as well as new tests that will validate the new fallback behavior for Edge.