### PR TITLE
Skip autoscaling on pan and zoom

### DIFF
--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -1313,7 +1313,7 @@ Licensed under the MIT license.
             }
         }
 
-        function setupGrid() {
+        function setupGrid(bypassAutoScale) {
             var i, a, axes = allAxes(),
                 showGrid = options.grid.show;
 
@@ -1340,7 +1340,7 @@ Licensed under the MIT license.
                 axis.reserveSpace = axisOpts.reserveSpace == null ? axis.show : axisOpts.reserveSpace;
                 setupTickFormatter(axis);
                 executeHooks(hooks.setRange, [axis]);
-                setRange(axis);
+                setRange(axis, bypassAutoScale);
             });
 
             if (showGrid) {
@@ -1355,7 +1355,7 @@ Licensed under the MIT license.
                     // make the ticks
                     setupTickGeneration(axis);
                     setMajorTicks(axis);
-                    snapRangeToTicks(axis, axis.ticks);
+                    snapRangeToTicks(axis, axis.ticks, bypassAutoScale);
 
                     //for computing the endpoints precision, transformationHelpers are needed
                     setTransformationHelpers(axis);
@@ -1439,7 +1439,7 @@ Licensed under the MIT license.
             };
         }
 
-        function autoScaleAxis(axis) {
+        function autoScaleAxis(axis, bypassAutoScale) {
             var opts = axis.options,
                 min = opts.min,
                 max = opts.max,
@@ -1453,7 +1453,7 @@ Licensed under the MIT license.
                     max = +(opts.max != null ? opts.max : datamax);
                     break;
                 case "loose":
-                    if (datamin != null && datamax != null) {
+                    if (datamin != null && datamax != null && !bypassAutoScale) {
                         min = datamin;
                         max = datamax;
                         delta = $.plot.saturated.saturate(max - min);
@@ -1498,8 +1498,8 @@ Licensed under the MIT license.
             axis.autoScaledMax = max;
         }
 
-        function setRange(axis) {
-            autoScaleAxis(axis);
+        function setRange(axis, bypassAutoScale) {
+            autoScaleAxis(axis, bypassAutoScale);
 
             var min = axis.autoScaledMin,
                 max = axis.autoScaledMax,
@@ -1735,8 +1735,8 @@ Licensed under the MIT license.
             };
         }
 
-        function snapRangeToTicks(axis, ticks) {
-            if (axis.options.autoScale === "loose" && ticks.length > 0) {
+        function snapRangeToTicks(axis, ticks, bypassAutoScale) {
+            if (axis.options.autoScale === "loose" && ticks.length > 0 && !bypassAutoScale) {
                 // snap to ticks
                 axis.min = Math.min(axis.min, ticks[0].v);
                 axis.max = Math.max(axis.max, ticks[ticks.length - 1].v);

--- a/source/jquery.flot.navigate.js
+++ b/source/jquery.flot.navigate.js
@@ -396,6 +396,8 @@ can set the default in the options.
                     }
                 };
 
+            var bypassAutoScale = true;
+
             for (var key in axes) {
                 if (!axes.hasOwnProperty(key)) {
                     continue;
@@ -424,9 +426,13 @@ can set the default in the options.
                 var offsetBelow = $.plot.saturated.saturate(navigationOffset.below - (axis.min - min));
                 var offsetAbove = $.plot.saturated.saturate(navigationOffset.above - (axis.max - max));
                 opts.offset = { below: offsetBelow, above: offsetAbove };
+
+                if (opts.min == null || opts.max == null) {
+                    bypassAutoScale = false;
+                }
             };
 
-            plot.setupGrid();
+            plot.setupGrid(bypassAutoScale);
             plot.draw();
 
             if (!args.preventEvent) {
@@ -435,6 +441,7 @@ can set the default in the options.
         };
 
         plot.pan = function(args) {
+            var bypassAutoScale = true;
             var delta = {
                 x: +args.left,
                 y: +args.top
@@ -468,10 +475,14 @@ can set the default in the options.
                         below: saturated.saturate(navigationOffsetBelow + (opts.offset.below || 0)),
                         above: saturated.saturate(navigationOffsetAbove + (opts.offset.above || 0))
                     };
+
+                    if (opts.min == null || opts.max == null) {
+                        bypassAutoScale = false;
+                    }
                 }
             });
 
-            plot.setupGrid();
+            plot.setupGrid(bypassAutoScale);
             plot.draw();
             if (!args.preventEvent) {
                 plot.getPlaceholder().trigger("plotpan", [plot, args]);
@@ -492,6 +503,17 @@ can set the default in the options.
             });
             plot.setupGrid();
             plot.draw();
+
+            // Reset min and max options to avoid snapping back to previous min and max
+            // when the plot is panned.
+            $.each(args.axes || plot.getAxes(), function(_, axis) {
+                if (args.axes) {
+                    axis.options.min = axis.min;
+                    axis.options.max = axis.max;
+                } else {
+                    axis.options.offset = { below: 0, above: 0 };
+                }
+            });
         };
 
         var shouldSnap = function(delta) {
@@ -576,6 +598,7 @@ can set the default in the options.
             }
 
             var axis, axisMin, axisMax, p, d;
+            var bypassAutoScale = true;
             Object.keys(axes).forEach(function(axisName) {
                 axis = axes[axisName];
                 axisMin = axis.min;
@@ -604,11 +627,15 @@ can set the default in the options.
 
                     axis.options.offset.below = saturated.saturate(navigationOffsetBelow + (axis.options.offset.below || 0));
                     axis.options.offset.above = saturated.saturate(navigationOffsetAbove + (axis.options.offset.above || 0));
+
+                    if (opts.min == null || opts.max == null) {
+                        bypassAutoScale = false;
+                    }
                 }
             });
 
             prevDelta = delta;
-            plot.setupGrid();
+            plot.setupGrid(bypassAutoScale);
             plot.draw();
 
             if (!preventEvent) {


### PR DESCRIPTION
I added an option to the `setupGrid` method to allow skipping autoscale for axes with `autoscale="loose"`.

In the navigate plugin, I updated `pan`, `zoom`, and `smartpan` to only autoscale if the axis min and max are not defined. Panning after recentering caused some jumping, so I also am resetting the min and max options at the end of `recenter`.