### PR TITLE
Fix stacking plugin

### DIFF
--- a/examples/stacking/index.html
+++ b/examples/stacking/index.html
@@ -6,7 +6,6 @@
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../source/jquery.js"></script>
 	<script language="javascript" type="text/javascript" src="../../dist/es5/jquery.flot.js"></script>
-	<script language="javascript" type="text/javascript" src="../../source/jquery.flot.stack.js"></script>
 	<script type="text/javascript">
 
 	$(function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ gulp.task('build_engineering_flot', function() {
         './source/jquery.flot.symbol.js',
         './source/jquery.flot.flatdata.js',
         './source/jquery.flot.navigate.js',
+        './source/jquery.flot.stack.js',
         './source/jquery.flot.touchNavigate.js',
         './source/jquery.flot.hover.js',
         './source/jquery.flot.touch.js',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -30,6 +30,7 @@ module.exports = function(config) {
         'source/jquery.flot.symbol.js',
         'source/jquery.flot.flatdata.js',
         'source/jquery.flot.navigate.js',
+        'source/jquery.flot.stack.js',
         'source/jquery.flot.touchNavigate.js',
         'source/jquery.flot.touch.js',
         'source/jquery.flot.absRelTime.js',

--- a/source/jquery.flot.drawSeries.js
+++ b/source/jquery.flot.drawSeries.js
@@ -499,13 +499,15 @@ This plugin is used by flot for drawing lines, plots, bars or area.
                 var points = datapoints.points,
                     ps = datapoints.pointsize,
                     fillTowards = series.bars.fillTowards || 0,
-                    bottom = fillTowards > axisy.min ? Math.min(axisy.max, fillTowards) : axisy.min;
+                    calculatedBottom = fillTowards > axisy.min ? Math.min(axisy.max, fillTowards) : axisy.min;
 
                 for (var i = 0; i < points.length; i += ps) {
                     if (points[i] == null) {
                         continue;
                     }
 
+                    // Use third point as bottom if pointsize is 3
+                    var bottom = ps === 3 ? points[i + 2] : calculatedBottom;
                     drawBar(points[i], points[i + 1], bottom, barLeft, barRight, fillStyleCallback, axisx, axisy, ctx, series.bars.lineWidth);
                 }
             }

--- a/tests/jquery.flot-drawSeries.Test.js
+++ b/tests/jquery.flot-drawSeries.Test.js
@@ -312,6 +312,24 @@ describe('drawSeries', function() {
             expect(ctx.lineTo).toHaveBeenCalled();
         });
 
+        it('should draw bars using bottom points if provided', function () {
+            getColorOrGradient = jasmine.createSpy().and.returnValue('rgb(10,200,10)');
+            series.bars.fill = true;
+
+            series.datapoints.points = [0, 10, 0, 1, 10, 1, 2, 10, 2];
+            series.datapoints.pointsize = 3;
+            spyOn(ctx, 'fillRect').and.callThrough();
+
+            drawSeriesBars(series, ctx, plotOffset, plotWidth, plotHeight, null, getColorOrGradient);
+
+            var barHeights = ctx.fillRect.calls.allArgs().map(function (args) {
+                return args[3];
+            });
+
+            // bottom - top
+            expect(barHeights).toEqual([-10, -9, -8]);
+        });
+
         it('should draw bars for fillTowards infinity', function () {
             series.datapoints.points = [150, 25];
             series.bars.fillTowards = Infinity;

--- a/tests/jquery.flot.stack.Test.js
+++ b/tests/jquery.flot.stack.Test.js
@@ -1,0 +1,46 @@
+/* eslint-disable */
+/* global $, describe, it, xit, xdescribe, after, afterEach, expect*/
+
+describe('stacking plugin', function() {
+    var placeholder, plot, options;
+
+    beforeEach(function() {
+        options = {
+            series: {
+                stack: true,
+                bars: {
+                    show: true,
+                    barWidth: 0.6
+                }
+            }
+        };
+
+        placeholder = setFixtures('<div id="test-container" style="width: 600px;height: 400px">')
+            .find('#test-container');
+    });
+
+    it('should accumulate Y values', function () {
+        var testData = [[[0, 1], [1, 2], [2, 3], [3, 4]], [[0, 4], [1, 3], [2, 2], [3, 1]]];
+        plot = $.plot(placeholder, testData, options);
+        var series = plot.getData();
+        expect(series[0].datapoints.pointsize).toBe(3);
+        expect(series[1].datapoints.pointsize).toBe(3);
+        var points1 = series[0].datapoints.points;
+        // Bottom points should be 0
+        expect(points1).toEqual([0, 1, 0, 1, 2, 0, 2, 3, 0, 3, 4, 0]);
+        var points2 = series[1].datapoints.points;
+        // Bottom points are first series' Y values
+        expect(points2).toEqual([0, 5, 1, 1, 5, 2, 2, 5, 3, 3, 5, 4]);
+    });
+
+    it('should format data when pointsize = 2', function () {
+        options.series.flatdata = true;
+        var testData = [[[0, 1], [1, 2], [2, 3], [3, 4]], [[0, 4], [1, 3], [2, 2], [3, 1]]];
+        plot = $.plot(placeholder, testData, options);
+        var series = plot.getData();
+        expect(series[0].datapoints.pointsize).toBe(3);
+        expect(series[1].datapoints.pointsize).toBe(3);
+        expect(series[0].datapoints.points.length).toEqual(12);
+        expect(series[1].datapoints.points.length).toEqual(12);
+    });
+});


### PR DESCRIPTION
This PR fixes the stacking plugin in engineering-flot and allows it to work without being affected by the jquery.flot.flatdata plugin and the 'fillTowards' option. 

In short, the two issues were:
- For stacked bar charts to work, flot needs to draw bars with a top, left, and bottom point. The 'fillTowards' option was being used even if there were bottom points.
- The flatdata plugin manually formats the 'datapoints' objects and prevents the stack plugin from getting the right format (x, y, bottom). Now, the stack plugin will check the format and correct it if necessary. 
