### PR TITLE
Handle issue where datapoints is undefined when hover/click event is …

### DIFF
--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -2495,8 +2495,9 @@ Licensed under the MIT license.
             for (i = series.length - 1; i >= 0; --i) {
                 if (!seriesFilter(i)) continue;
 
-                var s = series[i],
-                    x, y,
+                var s = series[i];
+                if (!s.datapoints) return;
+                var x, y,
                     axisx = s.xaxis,
                     axisy = s.yaxis,
                     points = s.datapoints.points,


### PR DESCRIPTION
…fired

This issue presents itself when the series are changed or the data is reset while the graph is still able to fire hover/click events