### PR TITLE
bubbles the onDrawingDone event

### DIFF
--- a/source/jquery.flot.js
+++ b/source/jquery.flot.js
@@ -2666,7 +2666,7 @@ Licensed under the MIT license.
             }
             overlay.clear();
             executeHooks(hooks.drawOverlay, [octx, overlay]);
-            var event = new CustomEvent('onDrawingDone');
+            var event = new CustomEvent('onDrawingDone', { bubbles: true });
             plot.getEventHolder().dispatchEvent(event);
         }
 


### PR DESCRIPTION
This change is based on an issue we meet after upgrade webcharts from 1.5 to 4.7:
  We add an event listener to this 'plot event holder' that listens to the onDrawingDone event before update some property of webcharts. However, the webcharts will destroy the flot object and create a new one instead, so the event holder and the listener will be removed, too. All the following async code will not be called. In a word, this event is not reliable if we are using webcharts.

The key point of the issue is how can our code capture an event to tell the plot drawing is done, no matter the plot is re-drawed or re-created. I thought though these three solutions:

  1. Add an event transporter to webcharts, which will listener to this 'onDrawingDone' event from the plot event holder, and trigger a corresponding event to the webcharts DOM element (e.g. ni-cartiesian-graph). In this way, webcharts will add the listener everytime it creates a new flot object. This solution is similar with the 'cursorupdated' event path. However, this change will be comparatively big.

  2. Dispatch the same event in flot, and change the event target to the 'place holder' but not the 'event holder'. In the current flot code, the 'plotpan' and 'plotzoom' events are already triggered via 'place holder', and the 'event holder' seems mostly used to capture origin user interaction like mouse down and touch start. 'onDrawingDone' is the only event that supposed to be used out-of-flot that dispatch to the event holder. Since the place holder is actually not a part of flot object and will not change when webchart replace the flot object, the event listeners on the place holder will still work. However, removing the current event dispatcher is very risky. It could already be used everywhere. So we have to keep both the event dispatchers (triggers), and it would increase the code redundancy.

  3. The simplest way as in this pull request. By bubbling the current event, we can move the listener to listen to an outer DOM element, which will not be removed with the flot object is destroyed. So the listener can alway hear the drawing done event, even the flot object has been replaced. It can solve that issue, and will not impact the old usage. In addition, it is the smallest change.

I still hesitate in the three solutions above, while the third one is my favorite, personally.@atmgrifter00 could you please tell your opinion and comments? Thanks.

It is a pre-review, I will add test and documents afterward.