### PR TITLE
Y Axis default timeBase should match X axis

### DIFF
--- a/source/jquery.flot.time.js
+++ b/source/jquery.flot.time.js
@@ -17,6 +17,9 @@ API.txt for details.
             twelveHourClock: false, // 12 or 24 time in time mode
             monthNames: null, // list of names of months
             timeBase: 'seconds' // are the values in milliseconds or seconds
+        },
+        yaxis: {
+            timeBase: 'seconds'
         }
     };
 


### PR DESCRIPTION
Ran into this in webcharts - when a timeBase wasn't specified it was being calculated as milliseconds