### PR TITLE
Update frameRate default value in documents to align with actual code

### DIFF
--- a/docs/navigate.md
+++ b/docs/navigate.md
@@ -20,7 +20,7 @@ The plugin supports these options:
         interactive: false,
         active: false,
         cursor: "move",     // CSS mouse cursor value used when dragging, e.g. "pointer"
-        frameRate: 20,
+        frameRate: 60,
         mode: "smart"       // enable smart pan mode
     }
 

--- a/source/jquery.flot.navigate.js
+++ b/source/jquery.flot.navigate.js
@@ -30,7 +30,7 @@ The plugin supports these options:
         interactive: false,
         active: false,
         cursor: "move",     // CSS mouse cursor value used when dragging, e.g. "pointer"
-        frameRate: 20,
+        frameRate: 60,
         mode: "smart"       // enable smart pan mode
     }
 


### PR DESCRIPTION
The actual value that used as frameRate is 60 in code (jquery.flot.navigate.js:110). However, the markdown document (navigate.md) writes 20, which could be misleading.

This PR align the documents to align the actual default value for frameRate.