### PR TITLE
Avoid possible spurious invalid event handling.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "engineering-flot",
-  "version": "1.6.3",
+  "version": "1.6.3-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engineering-flot",
-  "version": "1.6.3-hotfix",
+  "version": "1.6.3-hotfix.0",
   "main": "dist/es5/jquery.flot.js",
   "scripts": {
     "test": "node node_modules/karma/bin/karma start --single-run --no-auto-watch --concurrency=1 --stopOnEsLintError",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engineering-flot",
-  "version": "1.6.3",
+  "version": "1.6.3-hotfix",
   "main": "dist/es5/jquery.flot.js",
   "scripts": {
     "test": "node node_modules/karma/bin/karma start --single-run --no-auto-watch --concurrency=1 --stopOnEsLintError",

--- a/source/jquery.flot.navigate.js
+++ b/source/jquery.flot.navigate.js
@@ -259,6 +259,10 @@ can set the default in the options.
         }
 
         function onDrag(e) {
+            if (!isPanAction) {
+                return;
+            }
+
             var page = browser.getPageXY(e);
             var frameRate = plot.getOptions().pan.frameRate;
 
@@ -284,6 +288,10 @@ can set the default in the options.
         }
 
         function onDragEnd(e) {
+            if (!isPanAction) {
+                return;
+            }
+
             if (panTimeout) {
                 clearTimeout(panTimeout);
                 panTimeout = null;


### PR DESCRIPTION
It's possible for the onDrag, and onDragEnd event handlers to be called without the onDragStart handler having been called. Early return if this happens.